### PR TITLE
カード選択をより直感的なモーダルUIに改善

### DIFF
--- a/app/components/CardDisplay.tsx
+++ b/app/components/CardDisplay.tsx
@@ -1,64 +1,90 @@
-'use client';
+"use client";
 
-import React from 'react';
+import React from "react";
 
 interface CardProps {
   rank: string;
   suit: string;
-  size?: 'sm' | 'md' | 'lg';
+  size?: "sm" | "md" | "lg";
 }
 
-export default function CardDisplay({ rank, suit, size = 'md' }: CardProps) {
+export default function CardDisplay({ rank, suit, size = "md" }: CardProps) {
   if (!rank || !suit) return null;
-  
+
   // Size classes
   const sizeClasses = {
-    sm: 'text-lg',
-    md: 'text-2xl',
-    lg: 'text-4xl'
+    sm: "text-lg",
+    md: "text-2xl",
+    lg: "text-4xl",
   };
-  
+
   // Suit symbols and colors
   const suitSymbol = getSuitSymbol(suit);
   const suitColor = getSuitColor(suit);
-  
+
   return (
-    <div className={`inline-flex items-center justify-center rounded-md border border-gray-600 ${sizeClasses[size]} px-2 py-1 mx-1 bg-gray-800 font-bold ${suitColor}`}>
-      {rank}{suitSymbol}
+    <div
+      className={`inline-flex items-center justify-center rounded-md border border-gray-600 ${sizeClasses[size]} px-2 py-1 mx-1 bg-gray-800 font-bold ${suitColor}`}
+    >
+      {rank}
+      {suitSymbol}
     </div>
   );
 }
 
-export function CardsDisplay({ cards, size = 'md' }: { cards: Array<{rank: string, suit: string} | null>, size?: 'sm' | 'md' | 'lg' }) {
+export function CardsDisplay({
+  cards,
+  size = "md",
+}: {
+  cards: Array<{ rank: string; suit: string } | null>;
+  size?: "sm" | "md" | "lg";
+}) {
   return (
     <div className="flex space-x-1">
-      {cards.filter(card => card !== null).map((card, index) => (
-        card && <CardDisplay key={index} rank={card.rank} suit={card.suit} size={size} />
-      ))}
+      {cards
+        .filter((card) => card !== null)
+        .map(
+          (card, index) =>
+            card && (
+              <CardDisplay
+                key={index}
+                rank={card.rank}
+                suit={card.suit}
+                size={size}
+              />
+            )
+        )}
     </div>
   );
 }
 
 // Helper functions
 function getSuitSymbol(suit: string): string {
-  switch(suit.toLowerCase()) {
-    case 'h': return '♥'; // hearts
-    case 'd': return '♦'; // diamonds
-    case 's': return '♠'; // spades
-    case 'c': return '♣'; // clubs
-    default: return '';
+  switch (suit.toLowerCase()) {
+    case "h":
+      return "♥"; // hearts
+    case "d":
+      return "♦"; // diamonds
+    case "s":
+      return "♠"; // spades
+    case "c":
+      return "♣"; // clubs
+    default:
+      return "";
   }
 }
 
 function getSuitColor(suit: string): string {
-  switch(suit.toLowerCase()) {
-    case 'h': 
-    case 'd': 
-      return 'text-red-500';
-    case 's':
-    case 'c':
-      return 'text-white';
+  switch (suit.toLowerCase()) {
+    case "h":
+      return "text-red-500"; // ハート: 赤
+    case "d":
+      return "text-blue-500"; // ダイヤ: 青
+    case "c":
+      return "text-green-500"; // クラブ: 緑
+    case "s":
+      return "text-white"; // スペード: 白（ダークモードで視認性確保）
     default:
-      return '';
+      return "";
   }
 }


### PR DESCRIPTION
## 概要
- セレクトボックスによるカード選択を視覚的なモーダルUIに変更
- カードをグリッド表示に変更し、選択しやすく改善
- スート色を区別しやすいよう変更（ハート：赤、ダイヤ：青、クラブ：緑、スペード：白）

## 変更内容
- ハンド選択、フロップ、ターン、リバーのすべてのカード選択UIを改善
- カード選択状態の管理を改善し即時反映されるよう修正
- 使用済みカードは選択できないように非活性表示

## テスト方法
1. ポーカーハンド解析画面を開く
2. カード選択ボタンをクリックしてモーダルを表示
3. モーダルからカードを選択し、即時反映されることを確認
4. 各スート（ハート・ダイヤ・クラブ・スペード）が適切な色で表示されることを確認

Closes #2

🤖 Generated with [Claude Code](https://claude.ai/code)