### PR TITLE
Refactor: PokerForm コンポーネントを分割

### DIFF
--- a/app/components/BasicInfoForm.tsx
+++ b/app/components/BasicInfoForm.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import { HandHistoryState, Position, StackEntry } from "./types"; // Card は CardDisplay で使われるため不要、StackEntry は必要
+import CardDisplay from "./CardDisplay";
+
+interface BasicInfoFormProps {
+  handHistory: HandHistoryState;
+  // positionsByPlayerCount は getAvailablePositions で代替できるため削除
+  getAvailablePositions: () => Position[];
+  adjustPlayerCount: (delta: number) => void;
+  updateStack: (position: Position, value: number) => void;
+  updateHeroPosition: (position: Position) => void;
+  openCardSelector: (index: 0 | 1) => void; // Heroカード選択用
+  onNext: () => void; // 次のステップへ進む関数
+}
+
+export default function BasicInfoForm({
+  handHistory,
+  getAvailablePositions,
+  adjustPlayerCount,
+  updateStack,
+  updateHeroPosition,
+  openCardSelector,
+  onNext,
+}: BasicInfoFormProps) {
+  const isNextDisabled =
+    !handHistory.heroHand[0]?.rank ||
+    !handHistory.heroHand[0]?.suit ||
+    !handHistory.heroHand[1]?.rank ||
+    !handHistory.heroHand[1]?.suit;
+
+  return (
+    <div className="space-y-6">
+      <h3 className="text-xl font-semibold">ゲーム情報</h3>
+
+      {/* Player Count */}
+      <div>
+        <label className="block mb-2 text-sm font-medium">プレイヤー数</label>
+        <div className="flex items-center space-x-4">
+          <button
+            type="button"
+            onClick={() => adjustPlayerCount(-1)}
+            className="px-3 py-1 bg-gray-700 text-white rounded-md"
+            disabled={handHistory.playerCount <= 2}
+          >
+            -
+          </button>
+          <span className="text-lg font-medium">{handHistory.playerCount}</span>
+          <button
+            type="button"
+            onClick={() => adjustPlayerCount(1)}
+            className="px-3 py-1 bg-gray-700 text-white rounded-md"
+            disabled={handHistory.playerCount >= 9}
+          >
+            +
+          </button>
+        </div>
+      </div>
+
+      {/* Player Stacks */}
+      <div>
+        <label className="block mb-2 text-sm font-medium">スタック (BB)</label>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {handHistory.stacks.map(
+            (
+              stackEntry: StackEntry // 型アノテーションを追加
+            ) => (
+              <div key={stackEntry.position} className="flex flex-col">
+                {" "}
+                {/* key を index から position に変更 */}
+                <div className="flex items-center justify-between mb-1">
+                  <span className="text-sm flex items-center">
+                    {stackEntry.position}
+                    {stackEntry.isHero && (
+                      <span className="ml-1 px-1.5 py-0.5 text-xs bg-blue-600 text-white rounded">
+                        Hero
+                      </span>
+                    )}
+                  </span>
+                  <span className="text-sm font-semibold">
+                    {stackEntry.stack.toFixed(1)} BB
+                  </span>
+                </div>
+                <div className="flex flex-col space-y-2">
+                  <div className="flex items-center">
+                    <span className="text-xs mr-2">10</span>
+                    <input
+                      type="range"
+                      min="10"
+                      max="200"
+                      step="0.1"
+                      value={stackEntry.stack}
+                      onChange={(e) =>
+                        updateStack(
+                          stackEntry.position,
+                          parseFloat(e.target.value)
+                        )
+                      }
+                      className={`w-full ${
+                        stackEntry.isHero
+                          ? "accent-blue-600"
+                          : "accent-gray-500"
+                      }`}
+                    />
+                    <span className="text-xs ml-2">200</span>
+                  </div>
+                  <div className="flex items-center justify-end">
+                    <div className="relative w-20">
+                      <input
+                        type="number"
+                        min="1"
+                        max="999"
+                        value={String(stackEntry.stack)}
+                        step="0.1"
+                        onChange={(e) => {
+                          const value = parseFloat(e.target.value);
+                          if (!isNaN(value) && value > 0) {
+                            updateStack(stackEntry.position, value);
+                          }
+                        }}
+                        className={`w-full p-1 text-right pr-7 text-sm bg-white/5 border ${
+                          stackEntry.isHero
+                            ? "border-blue-600"
+                            : "border-gray-600"
+                        } rounded-md`}
+                      />
+                      <span className="absolute right-2 top-1/2 transform -translate-y-1/2 text-xs text-gray-400">
+                        BB
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            )
+          )}
+        </div>
+      </div>
+
+      {/* Hero Position */}
+      <div>
+        <label className="block mb-2 text-sm font-medium">
+          Heroのポジション
+        </label>
+        <div className="flex flex-wrap gap-2">
+          {getAvailablePositions().map((pos) => (
+            <button
+              key={pos}
+              type="button"
+              onClick={() => updateHeroPosition(pos)}
+              className={`px-3 py-1 rounded-md ${
+                handHistory.heroPosition === pos
+                  ? "bg-blue-600 text-white"
+                  : "bg-gray-700 text-white"
+              }`}
+            >
+              {pos}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Hero Hand */}
+      <div>
+        <label className="block mb-2 text-sm font-medium">Heroのハンド</label>
+
+        {/* Visual card display */}
+        <div className="mb-4 flex items-center">
+          <span className="mr-2">選択中:</span>
+          {handHistory.heroHand[0]?.rank && handHistory.heroHand[0]?.suit ? (
+            <button
+              type="button"
+              onClick={() => openCardSelector(0)}
+              className="hover:scale-105 transition-transform"
+            >
+              <CardDisplay
+                rank={handHistory.heroHand[0].rank}
+                suit={handHistory.heroHand[0].suit}
+                size="md"
+              />
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={() => openCardSelector(0)}
+              className="inline-flex items-center justify-center rounded-md border border-gray-600 text-2xl px-2 py-1 mx-1 bg-gray-800 text-gray-400 h-10 w-12"
+            >
+              ?
+            </button>
+          )}
+
+          {handHistory.heroHand[1]?.rank && handHistory.heroHand[1]?.suit ? (
+            <button
+              type="button"
+              onClick={() => openCardSelector(1)}
+              className="hover:scale-105 transition-transform"
+            >
+              <CardDisplay
+                rank={handHistory.heroHand[1].rank}
+                suit={handHistory.heroHand[1].suit}
+                size="md"
+              />
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={() => openCardSelector(1)}
+              className="inline-flex items-center justify-center rounded-md border border-gray-600 text-2xl px-2 py-1 mx-1 bg-gray-800 text-gray-400 h-10 w-12"
+            >
+              ?
+            </button>
+          )}
+        </div>
+
+        {/* Card selection buttons */}
+        <div className="flex space-x-4">
+          <button
+            type="button"
+            onClick={() => openCardSelector(0)}
+            className="px-3 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700"
+          >
+            カード1を選択
+          </button>
+          <button
+            type="button"
+            onClick={() => openCardSelector(1)}
+            className="px-3 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700"
+          >
+            カード2を選択
+          </button>
+        </div>
+      </div>
+
+      <div className="pt-4">
+        <button
+          type="button"
+          onClick={onNext}
+          className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50"
+          disabled={isNextDisabled}
+        >
+          次へ
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/components/BoardCardInput.tsx
+++ b/app/components/BoardCardInput.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import { HandHistoryState, Card } from "./types";
+import CardDisplay from "./CardDisplay";
+
+interface BoardCardInputProps {
+  stage: "flop" | "turn" | "river";
+  handHistory: HandHistoryState;
+  openFlopCardSelector?: (index: 0 | 1 | 2) => void;
+  openTurnCardSelector?: () => void;
+  openRiverCardSelector?: () => void;
+}
+
+export default function BoardCardInput({
+  stage,
+  handHistory,
+  openFlopCardSelector,
+  openTurnCardSelector,
+  openRiverCardSelector,
+}: BoardCardInputProps) {
+  const renderFlopInput = () => (
+    <div>
+      <label className="block mb-2 text-sm font-medium">フロップカード</label>
+      {/* Visual card display */}
+      {handHistory.flopCards[0]?.rank &&
+        handHistory.flopCards[0]?.suit &&
+        handHistory.flopCards[1]?.rank &&
+        handHistory.flopCards[1]?.suit &&
+        handHistory.flopCards[2]?.rank &&
+        handHistory.flopCards[2]?.suit && (
+          <div className="mb-4 flex items-center flex-wrap">
+            <span className="mr-2">ボード:</span>
+            {handHistory.flopCards.map(
+              (card, idx) =>
+                card && (
+                  <div
+                    key={idx}
+                    className={`inline-flex items-center justify-center rounded-md border border-gray-600 text-2xl px-2 py-1 mx-1 mb-2 bg-gray-800 font-bold ${
+                      card.suit === "h" || card.suit === "d"
+                        ? "text-red-500"
+                        : "text-white"
+                    }`}
+                  >
+                    {card.rank}
+                    {card.suit === "h"
+                      ? "♥"
+                      : card.suit === "d"
+                      ? "♦"
+                      : card.suit === "s"
+                      ? "♠"
+                      : "♣"}
+                  </div>
+                )
+            )}
+          </div>
+        )}
+
+      {/* Card selection */}
+      <div className="flex flex-wrap gap-4">
+        {[0, 1, 2].map((index) => (
+          <div key={index} className="space-y-2">
+            <label className="block text-xs">カード {index + 1}</label>
+            <div>
+              {handHistory.flopCards[index]?.rank &&
+              handHistory.flopCards[index]?.suit ? (
+                <button
+                  type="button"
+                  onClick={() => openFlopCardSelector?.(index as 0 | 1 | 2)}
+                  className="hover:scale-105 transition-transform"
+                >
+                  <CardDisplay
+                    rank={handHistory.flopCards[index]!.rank}
+                    suit={handHistory.flopCards[index]!.suit}
+                    size="md"
+                  />
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => openFlopCardSelector?.(index as 0 | 1 | 2)}
+                  className="inline-flex items-center justify-center rounded-md border border-gray-600 text-2xl px-4 py-2 mx-1 bg-gray-800 text-gray-400 hover:bg-gray-700 transition-colors h-10 w-16"
+                >
+                  選択
+                </button>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+
+  const renderTurnInput = () => (
+    <div>
+      <label className="block mb-2 text-sm font-medium">ターンカード</label>
+      {/* Visual card display */}
+      {handHistory.turnCard?.rank && handHistory.turnCard?.suit && (
+        <div className="mb-4 flex items-center flex-wrap">
+          <span className="mr-2">ターン:</span>
+          <div
+            className={`inline-flex items-center justify-center rounded-md border border-gray-600 text-2xl px-2 py-1 mx-1 mb-2 bg-gray-800 font-bold ${
+              handHistory.turnCard.suit === "h" ||
+              handHistory.turnCard.suit === "d"
+                ? "text-red-500"
+                : "text-white"
+            }`}
+          >
+            {handHistory.turnCard.rank}
+            {handHistory.turnCard.suit === "h"
+              ? "♥"
+              : handHistory.turnCard.suit === "d"
+              ? "♦"
+              : handHistory.turnCard.suit === "s"
+              ? "♠"
+              : "♣"}
+          </div>
+        </div>
+      )}
+
+      {/* Card selection */}
+      <div>
+        {handHistory.turnCard?.rank && handHistory.turnCard?.suit ? (
+          <button
+            type="button"
+            onClick={openTurnCardSelector}
+            className="hover:scale-105 transition-transform"
+          >
+            <CardDisplay
+              rank={handHistory.turnCard.rank}
+              suit={handHistory.turnCard.suit}
+              size="md"
+            />
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={openTurnCardSelector}
+            className="inline-flex items-center justify-center rounded-md border border-gray-600 text-lg px-4 py-2 bg-gray-800 text-gray-400 hover:bg-gray-700 transition-colors"
+          >
+            ターンカードを選択
+          </button>
+        )}
+      </div>
+    </div>
+  );
+
+  const renderRiverInput = () => (
+    <div>
+      <label className="block mb-2 text-sm font-medium">リバーカード</label>
+      {/* Visual card display */}
+      {handHistory.riverCard?.rank && handHistory.riverCard?.suit && (
+        <div className="mb-4 flex items-center flex-wrap">
+          <span className="mr-2">リバー:</span>
+          <div
+            className={`inline-flex items-center justify-center rounded-md border border-gray-600 text-2xl px-2 py-1 mx-1 mb-2 bg-gray-800 font-bold ${
+              handHistory.riverCard.suit === "h" ||
+              handHistory.riverCard.suit === "d"
+                ? "text-red-500"
+                : "text-white"
+            }`}
+          >
+            {handHistory.riverCard.rank}
+            {handHistory.riverCard.suit === "h"
+              ? "♥"
+              : handHistory.riverCard.suit === "d"
+              ? "♦"
+              : handHistory.riverCard.suit === "s"
+              ? "♠"
+              : "♣"}
+          </div>
+        </div>
+      )}
+
+      {/* Card selection */}
+      <div>
+        {handHistory.riverCard?.rank && handHistory.riverCard?.suit ? (
+          <button
+            type="button"
+            onClick={openRiverCardSelector}
+            className="hover:scale-105 transition-transform"
+          >
+            <CardDisplay
+              rank={handHistory.riverCard.rank}
+              suit={handHistory.riverCard.suit}
+              size="md"
+            />
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={openRiverCardSelector}
+            className="inline-flex items-center justify-center rounded-md border border-gray-600 text-lg px-4 py-2 bg-gray-800 text-gray-400 hover:bg-gray-700 transition-colors"
+          >
+            リバーカードを選択
+          </button>
+        )}
+      </div>
+    </div>
+  );
+
+  switch (stage) {
+    case "flop":
+      return renderFlopInput();
+    case "turn":
+      return renderTurnInput();
+    case "river":
+      return renderRiverInput();
+    default:
+      return null;
+  }
+}

--- a/app/components/CardSelectorModal.tsx
+++ b/app/components/CardSelectorModal.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { Card } from "./types";
+import CardDisplay from "./CardDisplay";
+
+interface CardSelectorModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSelectCard: (rank: string, suit: string) => void;
+  isCardAvailable: (rank: string, suit: string) => boolean;
+  currentCardType: "hero" | "flop" | "turn" | "river";
+  currentCardIndex?: 0 | 1; // Only for hero
+  currentFlopIndex?: 0 | 1 | 2; // Only for flop
+}
+
+const ranks = ["A", "K", "Q", "J", "T", "9", "8", "7", "6", "5", "4", "3", "2"];
+const suits = ["h", "d", "s", "c"];
+
+export default function CardSelectorModal({
+  isOpen,
+  onClose,
+  onSelectCard,
+  isCardAvailable,
+  currentCardType,
+  currentCardIndex,
+  currentFlopIndex,
+}: CardSelectorModalProps) {
+  if (!isOpen) return null;
+
+  let title = "カードを選択";
+  if (currentCardType === "hero" && currentCardIndex !== undefined) {
+    title = `ヒーロー カード${currentCardIndex + 1}を選択`;
+  } else if (currentCardType === "flop" && currentFlopIndex !== undefined) {
+    title = `フロップ カード${currentFlopIndex + 1}を選択`;
+  } else if (currentCardType === "turn") {
+    title = "ターンカードを選択";
+  } else if (currentCardType === "river") {
+    title = "リバーカードを選択";
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50">
+      <div className="bg-gray-800 rounded-lg p-6 w-full max-w-xl max-h-[80vh] overflow-y-auto">
+        <div className="flex justify-between items-center mb-4">
+          <h3 className="text-xl font-bold">{title}</h3>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-gray-400 hover:text-white"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="grid grid-cols-4 gap-2 sm:grid-cols-6 md:grid-cols-8">
+          {ranks.flatMap((rank) =>
+            suits.map((suit) => {
+              const available = isCardAvailable(rank, suit);
+              return (
+                <button
+                  key={`${rank}${suit}`}
+                  type="button"
+                  disabled={!available}
+                  onClick={() => available && onSelectCard(rank, suit)}
+                  className={`${
+                    available
+                      ? "cursor-pointer hover:scale-110 transition-transform"
+                      : "opacity-30 cursor-not-allowed"
+                  }`}
+                >
+                  <CardDisplay rank={rank} suit={suit} size="md" />
+                </button>
+              );
+            })
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/components/PokerForm.tsx
+++ b/app/components/PokerForm.tsx
@@ -1,60 +1,40 @@
 "use client";
 
 import { useState } from "react";
-import CardDisplay from "./CardDisplay";
+import {
+  HandHistoryState,
+  Position,
+  Card,
+  // Action, // Removed as it's not directly used here (used in StreetActionsForm)
+  ActionEntry,
+  StackEntry,
+  Street,
+} from "./types"; // Import types
+// CardDisplay is used indirectly via CardSelectorModal
+import BasicInfoForm from "./BasicInfoForm";
+import StreetActionsForm from "./StreetActionsForm";
+import BoardCardInput from "./BoardCardInput";
+import ReviewDisplay from "./ReviewDisplay";
+import CardSelectorModal from "./CardSelectorModal";
 
-type Position =
-  | "BTN"
-  | "SB"
-  | "BB"
-  | "UTG"
-  | "UTG+1"
-  | "MP"
-  | "MP+1"
-  | "HJ"
-  | "CO";
-type Card = { rank: string; suit: string };
-type Action = "fold" | "check" | "call" | "bet" | "raise" | "all-in" | "?";
-
-interface ActionEntry {
-  position: Position;
-  action: Action;
-  amount?: number;
-  isQuestion?: boolean;
-}
-
-interface StackEntry {
-  position: Position;
-  stack: number;
-  isHero?: boolean;
-}
-
-interface HandHistoryState {
-  heroHand: [Card | null, Card | null];
-  heroPosition: Position;
-  playerCount: number;
-  stacks: StackEntry[];
-  potSize: number;
-
-  preflopActions: Array<ActionEntry>;
-
-  flopCards: [Card | null, Card | null, Card | null];
-  flopActions: Array<ActionEntry>;
-
-  turnCard: Card | null;
-  turnActions: Array<ActionEntry>;
-
-  riverCard: Card | null;
-  riverActions: Array<ActionEntry>;
-
-  usedCards: Set<string>; // カードの重複使用を防ぐために使われたカードを追跡
-}
+// Constants used within this component
+const positionsByPlayerCount: Record<number, Position[]> = {
+  2: ["SB", "BB"],
+  3: ["BTN", "SB", "BB"],
+  4: ["BTN", "SB", "BB", "CO"],
+  5: ["BTN", "SB", "BB", "UTG", "CO"],
+  6: ["BTN", "SB", "BB", "UTG", "MP", "CO"],
+  7: ["BTN", "SB", "BB", "UTG", "UTG+1", "MP", "CO"],
+  8: ["BTN", "SB", "BB", "UTG", "UTG+1", "MP", "HJ", "CO"],
+  9: ["BTN", "SB", "BB", "UTG", "UTG+1", "MP", "MP+1", "HJ", "CO"],
+};
 
 export default function PokerForm({
   onAnalyze,
 }: {
   onAnalyze: (handHistory: string) => void;
 }) {
+  // State
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [step, setStep] = useState<number>(1);
   const [cardSelectorOpen, setCardSelectorOpen] = useState<boolean>(false);
@@ -63,77 +43,37 @@ export default function PokerForm({
     "hero" | "flop" | "turn" | "river"
   >("hero");
   const [currentFlopIndex, setCurrentFlopIndex] = useState<0 | 1 | 2>(0);
-  // ポジションテーブル - プレイヤー数ごとに有効なポジションを定義
-  const positionsByPlayerCount: Record<number, Position[]> = {
-    2: ["SB", "BB"],
-    3: ["BTN", "SB", "BB"],
-    4: ["BTN", "SB", "BB", "CO"],
-    5: ["BTN", "SB", "BB", "UTG", "CO"],
-    6: ["BTN", "SB", "BB", "UTG", "MP", "CO"],
-    7: ["BTN", "SB", "BB", "UTG", "UTG+1", "MP", "CO"],
-    8: ["BTN", "SB", "BB", "UTG", "UTG+1", "MP", "HJ", "CO"],
-    9: ["BTN", "SB", "BB", "UTG", "UTG+1", "MP", "MP+1", "HJ", "CO"],
-  };
 
-  // プレイヤー数に応じた初期スタック配列を生成
+  // Initial Stacks Helper
   const getInitialStacks = (playerCount: number): StackEntry[] => {
     const positions =
       positionsByPlayerCount[playerCount] || positionsByPlayerCount[6];
     return positions.map((position) => ({
       position,
       stack: 100.0,
-      isHero: position === "CO", // デフォルトではCOがHero
+      isHero: position === "CO", // Default Hero position
     }));
   };
 
+  // Hand History State
   const [handHistory, setHandHistory] = useState<HandHistoryState>({
     heroHand: [null, null],
     heroPosition: "CO",
     playerCount: 6,
     stacks: getInitialStacks(6),
     potSize: 0,
-
     preflopActions: [],
-
     flopCards: [null, null, null],
     flopActions: [],
-
     turnCard: null,
     turnActions: [],
-
     riverCard: null,
     riverActions: [],
-
     usedCards: new Set<string>(),
   });
 
-  const ranks = [
-    "A",
-    "K",
-    "Q",
-    "J",
-    "T",
-    "9",
-    "8",
-    "7",
-    "6",
-    "5",
-    "4",
-    "3",
-    "2",
-  ];
-  const suits = ["h", "d", "s", "c"];
-  const actions: Action[] = [
-    "fold",
-    "check",
-    "call",
-    "bet",
-    "raise",
-    "all-in",
-    "?",
-  ];
+  // --- Helper Functions ---
 
-  // 現在のプレイヤー数に応じた有効なポジションを取得
   const getAvailablePositions = (): Position[] => {
     return (
       positionsByPlayerCount[handHistory.playerCount] ||
@@ -143,32 +83,24 @@ export default function PokerForm({
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!validateForm()) return;
-
     setIsLoading(true);
     const formattedHistory = formatHandHistory();
-    onAnalyze(formattedHistory);
-  };
-
-  const validateForm = (): boolean => {
-    // Basic validation
-    if (!handHistory.heroHand[0] || !handHistory.heroHand[1]) return false;
-    return true;
+    setTimeout(() => {
+      onAnalyze(formattedHistory);
+      // Consider resetting isLoading state here or within onAnalyze callback
+      // setIsLoading(false);
+    }, 500);
   };
 
   const formatHandHistory = (): string => {
     let history = `### 前提条件\n\n`;
-
-    // Hero's hand
     const card1 = handHistory.heroHand[0];
     const card2 = handHistory.heroHand[1];
-    history += `- Hero のハンド: ${card1?.rank}${card1?.suit} ${card2?.rank}${card2?.suit}\n`;
-
-    // Position and players
+    history += `- Hero のハンド: ${card1?.rank ?? "?"}${card1?.suit ?? ""} ${
+      card2?.rank ?? "?"
+    }${card2?.suit ?? ""}\n`;
     history += `- Hero のポジション: ${handHistory.heroPosition}\n`;
-    history += `- 残りのプレイヤーの数: ${handHistory.playerCount}\n`;
-
-    // スタック情報をポジション名で出力
+    history += `- プレイヤー数: ${handHistory.playerCount}\n`;
     history += `- プレイヤーのスタック:\n`;
     handHistory.stacks.forEach((stackEntry) => {
       const positionName = stackEntry.isHero
@@ -176,41 +108,19 @@ export default function PokerForm({
         : stackEntry.position;
       history += `  - ${positionName}: ${stackEntry.stack.toFixed(1)}BB\n`;
     });
-
     history += `- 現在のポットサイズ: ${handHistory.potSize.toFixed(1)}BB\n`;
 
-    // Preflop actions
-    if (handHistory.preflopActions.length > 0) {
-      history += `- プリフロップのアクション:\n`;
-      handHistory.preflopActions.forEach((action) => {
-        // Heroの位置を強調表示
-        const positionName =
-          action.position === handHistory.heroPosition
-            ? `${action.position}(Hero)`
-            : action.position;
-        const amountText = action.amount
-          ? ` ${action.amount.toFixed(1)}BB`
-          : "";
-        history += `  - ${positionName}: ${action.action}${amountText}\n`;
-      });
-    }
-
-    // Flop
-    if (handHistory.flopCards[0]) {
-      const flop1 = handHistory.flopCards[0];
-      const flop2 = handHistory.flopCards[1];
-      const flop3 = handHistory.flopCards[2];
-
-      history += `\n### フロップ\n`;
-      history += `- フロップのボードカード: ${flop1.rank}${flop1.suit} ${flop2?.rank}${flop2?.suit} ${flop3?.rank}${flop3?.suit}\n`;
-      history += `- フロップ時点のポットサイズ: ${handHistory.potSize.toFixed(
-        1
-      )}BB\n`;
-
-      if (handHistory.flopActions.length > 0) {
-        history += `- フロップのアクション:\n`;
-        handHistory.flopActions.forEach((action) => {
-          // Heroの位置を強調表示
+    const formatActions = (street: Street, title: string) => {
+      const actions = handHistory[`${street}Actions`];
+      if (actions.length > 0) {
+        history += `\n### ${title}\n`;
+        // Pot size is already included in the board card section for flop/turn/river
+        if (street === "preflop") {
+          history += `- プリフロップのアクション:\n`;
+        } else {
+          history += `- ${title}のアクション:\n`;
+        }
+        actions.forEach((action) => {
           const positionName =
             action.position === handHistory.heroPosition
               ? `${action.position}(Hero)`
@@ -218,1552 +128,324 @@ export default function PokerForm({
           const amountText = action.amount
             ? ` ${action.amount.toFixed(1)}BB`
             : "";
-          history += `  - ${positionName}: ${action.action}${amountText}\n`;
+          const actionText =
+            action.action === "?" ? "分析を求める" : action.action;
+          history += `  - ${positionName}: ${actionText}${amountText}\n`;
         });
       }
+    };
+
+    formatActions("preflop", "プリフロップ");
+
+    const flop1 = handHistory.flopCards[0];
+    const flop2 = handHistory.flopCards[1];
+    const flop3 = handHistory.flopCards[2];
+    if (flop1 || flop2 || flop3) {
+      history += `\n### フロップ\n`;
+      history += `- フロップのボードカード: ${flop1?.rank ?? "?"}${
+        flop1?.suit ?? ""
+      } ${flop2?.rank ?? "?"}${flop2?.suit ?? ""} ${flop3?.rank ?? "?"}${
+        flop3?.suit ?? ""
+      }\n`;
+      history += `- フロップ時点のポットサイズ: ${handHistory.potSize.toFixed(
+        1
+      )}BB\n`; // Pot size reflects state *after* preflop actions
+      formatActions("flop", "フロップ");
     }
 
-    // Turn
-    if (handHistory.turnCard) {
-      const turn = handHistory.turnCard;
-
+    const turn = handHistory.turnCard;
+    if (turn) {
       history += `\n### ターン\n`;
       history += `- ターンのボードカード: ${turn.rank}${turn.suit}\n`;
       history += `- ターン時点のポットサイズ: ${handHistory.potSize.toFixed(
         1
-      )}BB\n`;
-
-      if (handHistory.turnActions.length > 0) {
-        history += `- ターンのアクション:\n`;
-        handHistory.turnActions.forEach((action) => {
-          // Heroの位置を強調表示
-          const positionName =
-            action.position === handHistory.heroPosition
-              ? `${action.position}(Hero)`
-              : action.position;
-          const amountText = action.amount
-            ? ` ${action.amount.toFixed(1)}BB`
-            : "";
-          history += `  - ${positionName}: ${action.action}${amountText}\n`;
-        });
-      }
+      )}BB\n`; // Pot size reflects state *after* flop actions
+      formatActions("turn", "ターン");
     }
 
-    // River
-    if (handHistory.riverCard) {
-      const river = handHistory.riverCard;
-
+    const river = handHistory.riverCard;
+    if (river) {
       history += `\n### リバー\n`;
       history += `- リバーのボードカード: ${river.rank}${river.suit}\n`;
       history += `- リバー時点のポットサイズ: ${handHistory.potSize.toFixed(
         1
-      )}BB\n`;
-
-      if (handHistory.riverActions.length > 0) {
-        history += `- リバーのアクション:\n`;
-        handHistory.riverActions.forEach((action) => {
-          // Heroの位置を強調表示
-          const positionName =
-            action.position === handHistory.heroPosition
-              ? `${action.position}(Hero)`
-              : action.position;
-          const amountText = action.amount
-            ? ` ${action.amount.toFixed(1)}BB`
-            : "";
-          history += `  - ${positionName}: ${action.action}${amountText}\n`;
-        });
-      }
+      )}BB\n`; // Pot size reflects state *after* turn actions
+      formatActions("river", "リバー");
     }
 
     return history;
   };
 
-  // ポットサイズを計算
-  const calculatePotSize = (actions: ActionEntry[]): number => {
-    return actions.reduce((pot, action) => {
-      if (
-        action.action === "bet" ||
-        action.action === "call" ||
-        action.action === "raise"
-      ) {
-        return pot + (action.amount || 0);
-      }
-      return pot;
-    }, 0);
-  };
+  // --- Card Update Handlers ---
+  const updateCardState = (
+    cardIdentifier:
+      | { type: "hero"; index: 0 | 1 }
+      | { type: "flop"; index: 0 | 1 | 2 }
+      | { type: "turn" }
+      | { type: "river" },
+    newCard: Card | null
+  ) => {
+    setHandHistory((prev) => {
+      const newState = { ...prev };
+      const usedCards = new Set(prev.usedCards);
+      let currentCard: Card | null = null;
 
-  // カードが既に使用されているかチェック
-  const isCardUsed = (rank: string, suit: string): boolean => {
-    if (!rank || !suit) return false;
-
-    const cardKey = `${rank}${suit}`;
-    return handHistory.usedCards.has(cardKey);
-  };
-
-  // 使用可能なカードのみをフィルタリング
-  const getAvailableRanks = (): string[] => {
-    return ranks;
-  };
-
-  const getAvailableSuits = (
-    selectedRank: string,
-    cardType: "hero" | "flop" | "turn" | "river",
-    index?: number
-  ): string[] => {
-    if (!selectedRank) return suits;
-
-    return suits.filter((suit) => {
-      // 現在編集中のカードの場合は、そのカードのスートは選択可能
-      if (
-        cardType === "hero" &&
-        index !== undefined &&
-        handHistory.heroHand[index]?.rank === selectedRank &&
-        handHistory.heroHand[index]?.suit === suit
-      ) {
-        return true;
+      // Identify current card and update state structure
+      if (cardIdentifier.type === "hero") {
+        currentCard = newState.heroHand[cardIdentifier.index];
+        newState.heroHand = [...newState.heroHand] as [
+          Card | null,
+          Card | null
+        ];
+        newState.heroHand[cardIdentifier.index] = newCard;
+      } else if (cardIdentifier.type === "flop") {
+        currentCard = newState.flopCards[cardIdentifier.index];
+        newState.flopCards = [...newState.flopCards] as [
+          Card | null,
+          Card | null,
+          Card | null
+        ];
+        newState.flopCards[cardIdentifier.index] = newCard;
+      } else if (cardIdentifier.type === "turn") {
+        currentCard = newState.turnCard;
+        newState.turnCard = newCard;
+      } else if (cardIdentifier.type === "river") {
+        currentCard = newState.riverCard;
+        newState.riverCard = newCard;
       }
 
-      if (
-        cardType === "flop" &&
-        index !== undefined &&
-        handHistory.flopCards[index]?.rank === selectedRank &&
-        handHistory.flopCards[index]?.suit === suit
-      ) {
-        return true;
+      // Update usedCards set
+      if (currentCard?.rank && currentCard?.suit) {
+        usedCards.delete(`${currentCard.rank}${currentCard.suit}`);
       }
-
-      if (
-        cardType === "turn" &&
-        handHistory.turnCard?.rank === selectedRank &&
-        handHistory.turnCard?.suit === suit
-      ) {
-        return true;
+      if (newCard?.rank && newCard?.suit) {
+        if (usedCards.has(`${newCard.rank}${newCard.suit}`)) {
+          console.error("Error: Trying to add an already used card:", newCard);
+        }
+        usedCards.add(`${newCard.rank}${newCard.suit}`);
       }
-
-      if (
-        cardType === "river" &&
-        handHistory.riverCard?.rank === selectedRank &&
-        handHistory.riverCard?.suit === suit
-      ) {
-        return true;
-      }
-
-      return !isCardUsed(selectedRank, suit);
+      newState.usedCards = usedCards;
+      return newState;
     });
   };
 
-  const updateHeroHand = (
-    cardIndex: 0 | 1,
-    field: "rank" | "suit",
-    value: string
-  ) => {
-    const newHand = [...handHistory.heroHand] as [Card | null, Card | null];
-    const currentCard = newHand[cardIndex] || { rank: "", suit: "" };
-    const newCard = { ...currentCard, [field]: value };
-
-    // 既存のカード情報を usedCards から削除
-    if (currentCard.rank && currentCard.suit) {
-      const usedCards = new Set(handHistory.usedCards);
-      usedCards.delete(`${currentCard.rank}${currentCard.suit}`);
-
-      // 新しいカード情報が完全な場合、usedCards に追加
-      if (newCard.rank && newCard.suit) {
-        usedCards.add(`${newCard.rank}${newCard.suit}`);
-      }
-
-      newHand[cardIndex] = newCard;
-      setHandHistory({
-        ...handHistory,
-        heroHand: newHand,
-        usedCards,
-      });
-    } else {
-      // 新しいカード情報が完全な場合
-      if (field === "suit" && currentCard.rank && value) {
-        const usedCards = new Set(handHistory.usedCards);
-        usedCards.add(`${currentCard.rank}${value}`);
-
-        newHand[cardIndex] = newCard;
-        setHandHistory({
-          ...handHistory,
-          heroHand: newHand,
-          usedCards,
-        });
-      } else if (field === "rank" && currentCard.suit && value) {
-        const usedCards = new Set(handHistory.usedCards);
-        usedCards.add(`${value}${currentCard.suit}`);
-
-        newHand[cardIndex] = newCard;
-        setHandHistory({
-          ...handHistory,
-          heroHand: newHand,
-          usedCards,
-        });
+  // --- Action Handlers ---
+  const addAction = (stage: Street, action: ActionEntry) => {
+    const actionField = `${stage}Actions` as keyof HandHistoryState;
+    setHandHistory((prev) => {
+      const currentActions = [...(prev[actionField] as ActionEntry[])];
+      const newAction = { ...action };
+      if (newAction.action === "?") {
+        newAction.isQuestion = true;
       } else {
-        // カード情報が不完全
-        newHand[cardIndex] = newCard;
-        setHandHistory({
-          ...handHistory,
-          heroHand: newHand,
-        });
+        newAction.isQuestion = false;
       }
-    }
-  };
+      currentActions.push(newAction);
 
-  const updateFlopCard = (
-    cardIndex: 0 | 1 | 2,
-    field: "rank" | "suit",
-    value: string
-  ) => {
-    const newFlop = [...handHistory.flopCards] as [
-      Card | null,
-      Card | null,
-      Card | null
-    ];
-    const currentCard = newFlop[cardIndex] || { rank: "", suit: "" };
-    const newCard = { ...currentCard, [field]: value };
-
-    // 既存のカード情報を usedCards から削除
-    if (currentCard.rank && currentCard.suit) {
-      const usedCards = new Set(handHistory.usedCards);
-      usedCards.delete(`${currentCard.rank}${currentCard.suit}`);
-
-      // 新しいカード情報が完全な場合、usedCards に追加
-      if (newCard.rank && newCard.suit) {
-        usedCards.add(`${newCard.rank}${newCard.suit}`);
+      let potIncrement = 0;
+      if (
+        (newAction.action === "bet" ||
+          newAction.action === "call" ||
+          newAction.action === "raise") &&
+        newAction.amount &&
+        newAction.amount > 0
+      ) {
+        potIncrement = newAction.amount;
       }
 
-      newFlop[cardIndex] = newCard;
-      setHandHistory({
-        ...handHistory,
-        flopCards: newFlop,
-        usedCards,
-      });
-    } else {
-      // 新しいカード情報が完全な場合
-      if (field === "suit" && currentCard.rank && value) {
-        const usedCards = new Set(handHistory.usedCards);
-        usedCards.add(`${currentCard.rank}${value}`);
-
-        newFlop[cardIndex] = newCard;
-        setHandHistory({
-          ...handHistory,
-          flopCards: newFlop,
-          usedCards,
-        });
-      } else if (field === "rank" && currentCard.suit && value) {
-        const usedCards = new Set(handHistory.usedCards);
-        usedCards.add(`${value}${currentCard.suit}`);
-
-        newFlop[cardIndex] = newCard;
-        setHandHistory({
-          ...handHistory,
-          flopCards: newFlop,
-          usedCards,
-        });
-      } else {
-        // カード情報が不完全
-        newFlop[cardIndex] = newCard;
-        setHandHistory({
-          ...handHistory,
-          flopCards: newFlop,
-        });
-      }
-    }
-  };
-
-  const updateTurnCard = (field: "rank" | "suit", value: string) => {
-    const currentCard = handHistory.turnCard || { rank: "", suit: "" };
-    const newCard = { ...currentCard, [field]: value };
-
-    // 既存のカード情報を usedCards から削除
-    if (currentCard.rank && currentCard.suit) {
-      const usedCards = new Set(handHistory.usedCards);
-      usedCards.delete(`${currentCard.rank}${currentCard.suit}`);
-
-      // 新しいカード情報が完全な場合、usedCards に追加
-      if (newCard.rank && newCard.suit) {
-        usedCards.add(`${newCard.rank}${newCard.suit}`);
-      }
-
-      setHandHistory({
-        ...handHistory,
-        turnCard: newCard,
-        usedCards,
-      });
-    } else {
-      // 新しいカード情報が完全な場合
-      if (field === "suit" && currentCard.rank && value) {
-        const usedCards = new Set(handHistory.usedCards);
-        usedCards.add(`${currentCard.rank}${value}`);
-
-        setHandHistory({
-          ...handHistory,
-          turnCard: newCard,
-          usedCards,
-        });
-      } else if (field === "rank" && currentCard.suit && value) {
-        const usedCards = new Set(handHistory.usedCards);
-        usedCards.add(`${value}${currentCard.suit}`);
-
-        setHandHistory({
-          ...handHistory,
-          turnCard: newCard,
-          usedCards,
-        });
-      } else {
-        // カード情報が不完全
-        setHandHistory({
-          ...handHistory,
-          turnCard: newCard,
-        });
-      }
-    }
-  };
-
-  const updateRiverCard = (field: "rank" | "suit", value: string) => {
-    const currentCard = handHistory.riverCard || { rank: "", suit: "" };
-    const newCard = { ...currentCard, [field]: value };
-
-    // 既存のカード情報を usedCards から削除
-    if (currentCard.rank && currentCard.suit) {
-      const usedCards = new Set(handHistory.usedCards);
-      usedCards.delete(`${currentCard.rank}${currentCard.suit}`);
-
-      // 新しいカード情報が完全な場合、usedCards に追加
-      if (newCard.rank && newCard.suit) {
-        usedCards.add(`${newCard.rank}${newCard.suit}`);
-      }
-
-      setHandHistory({
-        ...handHistory,
-        riverCard: newCard,
-        usedCards,
-      });
-    } else {
-      // 新しいカード情報が完全な場合
-      if (field === "suit" && currentCard.rank && value) {
-        const usedCards = new Set(handHistory.usedCards);
-        usedCards.add(`${currentCard.rank}${value}`);
-
-        setHandHistory({
-          ...handHistory,
-          riverCard: newCard,
-          usedCards,
-        });
-      } else if (field === "rank" && currentCard.suit && value) {
-        const usedCards = new Set(handHistory.usedCards);
-        usedCards.add(`${value}${currentCard.suit}`);
-
-        setHandHistory({
-          ...handHistory,
-          riverCard: newCard,
-          usedCards,
-        });
-      } else {
-        // カード情報が不完全
-        setHandHistory({
-          ...handHistory,
-          riverCard: newCard,
-        });
-      }
-    }
-  };
-
-  const addAction = (
-    stage: "preflop" | "flop" | "turn" | "river",
-    action: {
-      position: Position;
-      action: Action;
-      amount?: number;
-      isQuestion?: boolean;
-    }
-  ) => {
-    const actionField = `${stage}Actions`;
-    const currentActions = [...(handHistory as any)[actionField]];
-
-    // 「?」アクションの場合
-    if (action.action === "?") {
-      action.isQuestion = true;
-    }
-
-    currentActions.push(action);
-
-    // ポットサイズを更新
-    let potIncrement = 0;
-    if (
-      (action.action === "bet" ||
-        action.action === "call" ||
-        action.action === "raise") &&
-      action.amount
-    ) {
-      potIncrement = action.amount;
-    }
-
-    const newState = {
-      ...handHistory,
-      [actionField]: currentActions,
-      potSize: handHistory.potSize + potIncrement,
-    };
-
-    setHandHistory(newState);
-
-    // 「?」アクションの場合はすぐに解析実行 - 状態更新後に実行するため setTimeout を使用
-    if (action.action === "?") {
-      // 次のティックで実行することで、ステート更新が完了することを保証
-      // また、最新のハンド履歴を再取得する
-      setTimeout(() => {
-        // 最新の状態でフォーマット
-        const formattedHistory = formatHandHistory();
-        onAnalyze(formattedHistory);
-
-        // 解析中の状態を視覚的に示す
-        // UIが早すぎると解析が始まった感じがしないため、短いディレイを追加
-        setTimeout(() => {
-          document
-            .getElementById("analysis-section")
-            ?.scrollIntoView({ behavior: "smooth" });
-        }, 300);
-      }, 10);
-    }
-  };
-
-  const removeAction = (
-    stage: "preflop" | "flop" | "turn" | "river",
-    index: number
-  ) => {
-    const actionField = `${stage}Actions`;
-    const currentActions = [...(handHistory as any)[actionField]];
-
-    // 削除するアクションがポットサイズに影響する場合、ポットサイズを減少
-    const removedAction = currentActions[index];
-    let potDecrement = 0;
-    if (
-      (removedAction.action === "bet" ||
-        removedAction.action === "call" ||
-        removedAction.action === "raise") &&
-      removedAction.amount
-    ) {
-      potDecrement = removedAction.amount;
-    }
-
-    currentActions.splice(index, 1);
-
-    setHandHistory({
-      ...handHistory,
-      [actionField]: currentActions,
-      potSize: Math.max(0, handHistory.potSize - potDecrement), // ポットサイズが負にならないよう保証
+      return {
+        ...prev,
+        [actionField]: currentActions,
+        potSize: prev.potSize + potIncrement,
+      };
     });
   };
 
+  const removeAction = (stage: Street, index: number) => {
+    const actionField = `${stage}Actions` as keyof HandHistoryState;
+    setHandHistory((prev) => {
+      const currentActions = [...(prev[actionField] as ActionEntry[])];
+      const removedAction = currentActions[index];
+      let potDecrement = 0;
+      if (
+        (removedAction.action === "bet" ||
+          removedAction.action === "call" ||
+          removedAction.action === "raise") &&
+        removedAction.amount &&
+        removedAction.amount > 0
+      ) {
+        potDecrement = removedAction.amount;
+      }
+      currentActions.splice(index, 1);
+      return {
+        ...prev,
+        [actionField]: currentActions,
+        potSize: Math.max(0, prev.potSize - potDecrement),
+      };
+    });
+  };
+
+  // --- Basic Info Handlers ---
   const adjustPlayerCount = (delta: number) => {
-    const newCount = Math.max(2, Math.min(9, handHistory.playerCount + delta));
+    setHandHistory((prev) => {
+      const newCount = Math.max(2, Math.min(9, prev.playerCount + delta));
+      if (newCount === prev.playerCount) return prev;
 
-    // プレイヤー数に合わせたポジションとスタックを再構成
-    const newPositions = positionsByPlayerCount[newCount];
-    const newStacks = getInitialStacks(newCount);
-
-    // Heroのポジションが新しいポジション一覧に含まれているか確認
-    const heroPosition = newPositions.includes(handHistory.heroPosition)
-      ? handHistory.heroPosition
-      : newPositions[newPositions.length - 1]; // デフォルトは最後のポジション
-
-    // スタックにHeroを設定
-    const updatedStacks = newStacks.map((stack) => ({
-      ...stack,
-      isHero: stack.position === heroPosition,
-    }));
-
-    setHandHistory({
-      ...handHistory,
-      playerCount: newCount,
-      stacks: updatedStacks,
-      heroPosition,
+      const newPositions = positionsByPlayerCount[newCount];
+      const newStacks = getInitialStacks(newCount);
+      const heroPosition = newPositions.includes(prev.heroPosition)
+        ? prev.heroPosition
+        : newPositions[newPositions.length - 1];
+      const updatedStacks = newStacks.map((stack) => ({
+        ...stack,
+        isHero: stack.position === heroPosition,
+      }));
+      return {
+        ...prev,
+        playerCount: newCount,
+        stacks: updatedStacks,
+        heroPosition,
+      };
     });
   };
 
   const updateStack = (position: Position, value: number) => {
-    const newStacks = handHistory.stacks.map((stack) =>
-      stack.position === position ? { ...stack, stack: value } : stack
-    );
-
-    setHandHistory({
-      ...handHistory,
-      stacks: newStacks,
-    });
-  };
-
-  // Heroのポジションを更新
-  const updateHeroPosition = (position: Position) => {
-    // 新しいスタック配列を作成し、Hero位置を更新
-    const newStacks = handHistory.stacks.map((stack) => ({
-      ...stack,
-      isHero: stack.position === position,
+    setHandHistory((prev) => ({
+      ...prev,
+      stacks: prev.stacks.map((stack) =>
+        stack.position === position
+          ? { ...stack, stack: Math.max(0, value) }
+          : stack
+      ),
     }));
-
-    setHandHistory({
-      ...handHistory,
-      heroPosition: position,
-      stacks: newStacks,
-    });
   };
 
-  // カード選択モーダルを開く
+  const updateHeroPosition = (position: Position) => {
+    setHandHistory((prev) => ({
+      ...prev,
+      heroPosition: position,
+      stacks: prev.stacks.map((stack) => ({
+        ...stack,
+        isHero: stack.position === position,
+      })),
+    }));
+  };
+
+  // --- Card Selector Modal Handlers ---
   const openCardSelector = (index: 0 | 1) => {
     setCurrentCardIndex(index);
     setCurrentCardType("hero");
     setCardSelectorOpen(true);
   };
 
-  // フロップカード選択モーダルを開く
   const openFlopCardSelector = (index: 0 | 1 | 2) => {
     setCurrentFlopIndex(index);
     setCurrentCardType("flop");
     setCardSelectorOpen(true);
   };
 
-  // ターンカード選択モーダルを開く
   const openTurnCardSelector = () => {
     setCurrentCardType("turn");
     setCardSelectorOpen(true);
   };
 
-  // リバーカード選択モーダルを開く
   const openRiverCardSelector = () => {
     setCurrentCardType("river");
     setCardSelectorOpen(true);
   };
 
-  // カードを選択
   const selectCard = (rank: string, suit: string) => {
-    if (currentCardType === "hero") {
-      // 直接ステートを更新
-      const newHand = [...handHistory.heroHand] as [Card | null, Card | null];
-      const newCard = { rank, suit };
-
-      // 現在のカードを削除
-      const usedCards = new Set(handHistory.usedCards);
-      const currentCard = handHistory.heroHand[currentCardIndex];
-      if (currentCard?.rank && currentCard?.suit) {
-        usedCards.delete(`${currentCard.rank}${currentCard.suit}`);
-      }
-
-      // 新しいカードを追加
-      usedCards.add(`${rank}${suit}`);
-      newHand[currentCardIndex] = newCard;
-
-      setHandHistory({
-        ...handHistory,
-        heroHand: newHand,
-        usedCards,
-      });
-    } else if (currentCardType === "flop") {
-      // フロップの直接更新
-      const newFlop = [...handHistory.flopCards] as [
-        Card | null,
-        Card | null,
-        Card | null
-      ];
-      const newCard = { rank, suit };
-
-      // 現在のカードを削除
-      const usedCards = new Set(handHistory.usedCards);
-      const currentCard = handHistory.flopCards[currentFlopIndex];
-      if (currentCard?.rank && currentCard?.suit) {
-        usedCards.delete(`${currentCard.rank}${currentCard.suit}`);
-      }
-
-      // 新しいカードを追加
-      usedCards.add(`${rank}${suit}`);
-      newFlop[currentFlopIndex] = newCard;
-
-      setHandHistory({
-        ...handHistory,
-        flopCards: newFlop,
-        usedCards,
-      });
-    } else if (currentCardType === "turn") {
-      // ターンの直接更新
-      const usedCards = new Set(handHistory.usedCards);
-      const currentCard = handHistory.turnCard;
-      if (currentCard?.rank && currentCard?.suit) {
-        usedCards.delete(`${currentCard.rank}${currentCard.suit}`);
-      }
-
-      // 新しいカードを追加
-      usedCards.add(`${rank}${suit}`);
-
-      setHandHistory({
-        ...handHistory,
-        turnCard: { rank, suit },
-        usedCards,
-      });
-    } else if (currentCardType === "river") {
-      // リバーの直接更新
-      const usedCards = new Set(handHistory.usedCards);
-      const currentCard = handHistory.riverCard;
-      if (currentCard?.rank && currentCard?.suit) {
-        usedCards.delete(`${currentCard.rank}${currentCard.suit}`);
-      }
-
-      // 新しいカードを追加
-      usedCards.add(`${rank}${suit}`);
-
-      setHandHistory({
-        ...handHistory,
-        riverCard: { rank, suit },
-        usedCards,
-      });
+    if (!isCardAvailableForModal(rank, suit)) {
+      console.error("Selected card is not available:", rank, suit);
+      return;
     }
+
+    const newCard: Card = { rank, suit };
+    let identifier:
+      | { type: "hero"; index: 0 | 1 }
+      | { type: "flop"; index: 0 | 1 | 2 }
+      | { type: "turn" }
+      | { type: "river" };
+
+    if (currentCardType === "hero") {
+      identifier = { type: "hero", index: currentCardIndex };
+    } else if (currentCardType === "flop") {
+      identifier = { type: "flop", index: currentFlopIndex };
+    } else if (currentCardType === "turn") {
+      identifier = { type: "turn" };
+    } else {
+      identifier = { type: "river" };
+    }
+
+    updateCardState(identifier, newCard);
     setCardSelectorOpen(false);
   };
 
-  // Step 1: Basic Info
-  const renderBasicInfoStep = () => (
-    <div className="space-y-6">
-      <h3 className="text-xl font-semibold">ゲーム情報</h3>
+  const isCardAvailableForModal = (rank: string, suit: string): boolean => {
+    // const cardKey = `${rank}${suit}`; // Removed as unused
+    let isUsedElsewhere = false;
 
-      {/* Player Count */}
-      <div>
-        <label className="block mb-2 text-sm font-medium">プレイヤー数</label>
-        <div className="flex items-center space-x-4">
-          <button
-            type="button"
-            onClick={() => adjustPlayerCount(-1)}
-            className="px-3 py-1 bg-gray-700 text-white rounded-md"
-            disabled={handHistory.playerCount <= 2}
-          >
-            -
-          </button>
-          <span className="text-lg font-medium">{handHistory.playerCount}</span>
-          <button
-            type="button"
-            onClick={() => adjustPlayerCount(1)}
-            className="px-3 py-1 bg-gray-700 text-white rounded-md"
-            disabled={handHistory.playerCount >= 9}
-          >
-            +
-          </button>
-        </div>
-      </div>
-
-      {/* Player Stacks */}
-      <div>
-        <label className="block mb-2 text-sm font-medium">スタック (BB)</label>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          {handHistory.stacks.map((stackEntry, index) => (
-            <div key={index} className="flex flex-col">
-              <div className="flex items-center justify-between mb-1">
-                <span className="text-sm flex items-center">
-                  {stackEntry.position}
-                  {stackEntry.isHero && (
-                    <span className="ml-1 px-1.5 py-0.5 text-xs bg-blue-600 text-white rounded">
-                      Hero
-                    </span>
-                  )}
-                </span>
-                <span className="text-sm font-semibold">
-                  {stackEntry.stack.toFixed(1)} BB
-                </span>
-              </div>
-              <div className="flex flex-col space-y-2">
-                <div className="flex items-center">
-                  <span className="text-xs mr-2">10</span>
-                  <input
-                    type="range"
-                    min="10"
-                    max="200"
-                    step="0.1"
-                    value={stackEntry.stack}
-                    onChange={(e) =>
-                      updateStack(
-                        stackEntry.position,
-                        parseFloat(e.target.value)
-                      )
-                    }
-                    className={`w-full ${
-                      stackEntry.isHero ? "accent-blue-600" : "accent-gray-500"
-                    }`}
-                  />
-                  <span className="text-xs ml-2">200</span>
-                </div>
-                <div className="flex items-center justify-end">
-                  <div className="relative w-20">
-                    <input
-                      type="number"
-                      min="1"
-                      max="999"
-                      value={String(stackEntry.stack)}
-                      step="0.1"
-                      onChange={(e) => {
-                        const value = parseFloat(e.target.value);
-                        if (!isNaN(value) && value > 0) {
-                          updateStack(stackEntry.position, value);
-                        }
-                      }}
-                      className={`w-full p-1 text-right pr-7 text-sm bg-white/5 border ${
-                        stackEntry.isHero
-                          ? "border-blue-600"
-                          : "border-gray-600"
-                      } rounded-md`}
-                    />
-                    <span className="absolute right-2 top-1/2 transform -translate-y-1/2 text-xs text-gray-400">
-                      BB
-                    </span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          ))}
-        </div>
-      </div>
-
-      {/* Hero Position */}
-      <div>
-        <label className="block mb-2 text-sm font-medium">
-          Heroのポジション
-        </label>
-        <div className="flex flex-wrap gap-2">
-          {getAvailablePositions().map((pos) => (
-            <button
-              key={pos}
-              type="button"
-              onClick={() => updateHeroPosition(pos)}
-              className={`px-3 py-1 rounded-md ${
-                handHistory.heroPosition === pos
-                  ? "bg-blue-600 text-white"
-                  : "bg-gray-700 text-white"
-              }`}
-            >
-              {pos}
-            </button>
-          ))}
-        </div>
-      </div>
-
-      {/* Hero Hand */}
-      <div>
-        <label className="block mb-2 text-sm font-medium">Heroのハンド</label>
-
-        {/* Visual card display */}
-        <div className="mb-4 flex items-center">
-          <span className="mr-2">選択中:</span>
-          {handHistory.heroHand[0]?.rank && handHistory.heroHand[0]?.suit ? (
-            <div
-              className={`inline-flex items-center justify-center rounded-md border border-gray-600 text-2xl px-2 py-1 mx-1 bg-gray-800 font-bold ${
-                handHistory.heroHand[0]?.suit === "h" ||
-                handHistory.heroHand[0]?.suit === "d"
-                  ? "text-red-500"
-                  : "text-white"
-              }`}
-            >
-              {handHistory.heroHand[0]?.rank}
-              {handHistory.heroHand[0]?.suit === "h"
-                ? "♥"
-                : handHistory.heroHand[0]?.suit === "d"
-                ? "♦"
-                : handHistory.heroHand[0]?.suit === "s"
-                ? "♠"
-                : "♣"}
-            </div>
-          ) : (
-            <button
-              onClick={() => openCardSelector(0)}
-              className="inline-flex items-center justify-center rounded-md border border-gray-600 text-2xl px-2 py-1 mx-1 bg-gray-800 text-gray-400 h-10 w-12"
-            >
-              ?
-            </button>
-          )}
-
-          {handHistory.heroHand[1]?.rank && handHistory.heroHand[1]?.suit ? (
-            <div
-              className={`inline-flex items-center justify-center rounded-md border border-gray-600 text-2xl px-2 py-1 mx-1 bg-gray-800 font-bold ${
-                handHistory.heroHand[1]?.suit === "h" ||
-                handHistory.heroHand[1]?.suit === "d"
-                  ? "text-red-500"
-                  : "text-white"
-              }`}
-            >
-              {handHistory.heroHand[1]?.rank}
-              {handHistory.heroHand[1]?.suit === "h"
-                ? "♥"
-                : handHistory.heroHand[1]?.suit === "d"
-                ? "♦"
-                : handHistory.heroHand[1]?.suit === "s"
-                ? "♠"
-                : "♣"}
-            </div>
-          ) : (
-            <button
-              onClick={() => openCardSelector(1)}
-              className="inline-flex items-center justify-center rounded-md border border-gray-600 text-2xl px-2 py-1 mx-1 bg-gray-800 text-gray-400 h-10 w-12"
-            >
-              ?
-            </button>
-          )}
-        </div>
-
-        {/* Card selection buttons */}
-        <div className="flex space-x-4">
-          <button
-            type="button"
-            onClick={() => openCardSelector(0)}
-            className="px-3 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700"
-          >
-            カード1を選択
-          </button>
-          <button
-            type="button"
-            onClick={() => openCardSelector(1)}
-            className="px-3 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700"
-          >
-            カード2を選択
-          </button>
-        </div>
-      </div>
-
-      <div className="pt-4">
-        <button
-          type="button"
-          onClick={() => setStep(2)}
-          className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700"
-          disabled={
-            !handHistory.heroHand[0]?.rank ||
-            !handHistory.heroHand[0]?.suit ||
-            !handHistory.heroHand[1]?.rank ||
-            !handHistory.heroHand[1]?.suit
-          }
-        >
-          次へ
-        </button>
-      </div>
-    </div>
-  );
-
-  // Action Input Component
-  const ActionInputComponent = ({
-    stage,
-  }: {
-    stage: "preflop" | "flop" | "turn" | "river";
-  }) => {
-    const [newAction, setNewAction] = useState<{
-      position: Position;
-      action: Action;
-      amount?: number;
-      isQuestion?: boolean;
-    }>({
-      position: handHistory.heroPosition,
-      action: "check",
-      amount: undefined,
+    // Check Hero Hand
+    [0, 1].forEach((idx) => {
+      if (!(currentCardType === "hero" && currentCardIndex === idx)) {
+        if (
+          handHistory.heroHand[idx]?.rank === rank &&
+          handHistory.heroHand[idx]?.suit === suit
+        ) {
+          isUsedElsewhere = true;
+        }
+      }
     });
+    if (isUsedElsewhere) return false;
 
-    const needsAmount = ["bet", "raise", "call"].includes(newAction.action);
-    const isQuestion = newAction.action === "?";
-
-    return (
-      <div className="space-y-4 border border-gray-700 rounded-md p-4 mt-4">
-        <div className="flex justify-between items-center">
-          <h4 className="font-medium">新しいアクション</h4>
-          <div className="text-sm bg-blue-900 px-3 py-1 rounded-md">
-            現在のポット:{" "}
-            <span className="font-bold">
-              {handHistory.potSize.toFixed(1)}BB
-            </span>
-          </div>
-        </div>
-
-        <div className="grid grid-cols-2 gap-3">
-          <div>
-            <label className="block text-xs mb-1">ポジション</label>
-            <select
-              value={newAction.position}
-              onChange={(e) =>
-                setNewAction({
-                  ...newAction,
-                  position: e.target.value as Position,
-                })
-              }
-              className="w-full p-2 bg-white/5 border border-gray-600 rounded-md"
-            >
-              {getAvailablePositions().map((pos) => (
-                <option key={pos} value={pos}>
-                  {pos === handHistory.heroPosition ? `${pos} (Hero)` : pos}
-                </option>
-              ))}
-            </select>
-          </div>
-
-          <div>
-            <label className="block text-xs mb-1">アクション</label>
-            <select
-              value={newAction.action}
-              onChange={(e) =>
-                setNewAction({ ...newAction, action: e.target.value as Action })
-              }
-              className="w-full p-2 bg-white/5 border border-gray-600 rounded-md"
-            >
-              {actions.map((action) => (
-                <option key={action} value={action}>
-                  {action === "?" ? "? (解析)" : action}
-                </option>
-              ))}
-            </select>
-          </div>
-
-          {needsAmount && (
-            <div className="col-span-2">
-              <label className="block text-xs mb-1">金額 (BB)</label>
-              <input
-                type="number"
-                min="0.5"
-                step="0.5"
-                value={newAction.amount || ""}
-                onChange={(e) =>
-                  setNewAction({
-                    ...newAction,
-                    amount: parseFloat(e.target.value) || undefined,
-                  })
-                }
-                className="w-full p-2 bg-white/5 border border-gray-600 rounded-md"
-              />
-            </div>
-          )}
-        </div>
-
-        <div className="flex justify-between">
-          <button
-            type="button"
-            onClick={() => {
-              addAction(stage, newAction);
-              // Heroのポジションを保持したまま新しいアクションをセット
-              setNewAction({
-                position: handHistory.heroPosition,
-                action: "check",
-                amount: undefined,
-              });
-            }}
-            className={`px-3 py-1 ${
-              isQuestion
-                ? "bg-green-600 hover:bg-green-700"
-                : "bg-blue-600 hover:bg-blue-700"
-            } text-white rounded-md`}
-            disabled={needsAmount && !newAction.amount}
-          >
-            {isQuestion ? "解析する" : "追加"}
-          </button>
-
-          {isQuestion && (
-            <div className="text-yellow-400 text-sm italic">
-              「?」を追加すると、この時点での最適なアクションを解析します
-            </div>
-          )}
-        </div>
-      </div>
-    );
-  };
-
-  // Step 2: Preflop
-  const renderPreflopStep = () => (
-    <div className="space-y-6">
-      <h3 className="text-xl font-semibold">プリフロップ</h3>
-
-      <div>
-        <label className="block mb-2 text-sm font-medium">
-          プリフロップのアクション
-        </label>
-
-        {handHistory.preflopActions.length > 0 ? (
-          <div className="space-y-2 mb-4">
-            {handHistory.preflopActions.map((action, index) => (
-              <div
-                key={index}
-                className={`flex items-center justify-between p-2 rounded-md ${
-                  action.action === "?"
-                    ? "bg-green-900"
-                    : action.position === handHistory.heroPosition
-                    ? "bg-blue-900"
-                    : "bg-gray-800"
-                }`}
-              >
-                <span>
-                  {action.position === handHistory.heroPosition
-                    ? `${action.position} (Hero)`
-                    : action.position}
-                  : {action.action === "?" ? "分析を求める" : action.action}
-                  {action.amount !== undefined
-                    ? ` ${action.amount.toFixed(1)}BB`
-                    : ""}
-                </span>
-                <button
-                  type="button"
-                  onClick={() => removeAction("preflop", index)}
-                  className="text-red-500 hover:text-red-400"
-                >
-                  ×
-                </button>
-              </div>
-            ))}
-          </div>
-        ) : (
-          <p className="text-gray-400 text-sm mb-4">
-            アクションが記録されていません。
-          </p>
-        )}
-
-        <ActionInputComponent stage="preflop" />
-      </div>
-
-      <div className="flex justify-between pt-4">
-        <button
-          type="button"
-          onClick={() => setStep(1)}
-          className="px-4 py-2 bg-gray-600 text-white rounded-md hover:bg-gray-700"
-        >
-          戻る
-        </button>
-        <button
-          type="button"
-          onClick={() => setStep(3)}
-          className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700"
-        >
-          次へ
-        </button>
-      </div>
-    </div>
-  );
-
-  // Step 3: Flop
-  const renderFlopStep = () => (
-    <div className="space-y-6">
-      <h3 className="text-xl font-semibold">フロップ</h3>
-
-      {/* Flop Cards */}
-      <div>
-        <label className="block mb-2 text-sm font-medium">フロップカード</label>
-
-        {/* Visual card display */}
-        {handHistory.flopCards[0]?.rank &&
-          handHistory.flopCards[0]?.suit &&
-          handHistory.flopCards[1]?.rank &&
-          handHistory.flopCards[1]?.suit &&
-          handHistory.flopCards[2]?.rank &&
-          handHistory.flopCards[2]?.suit && (
-            <div className="mb-4 flex items-center flex-wrap">
-              <span className="mr-2">ボード:</span>
-              {handHistory.flopCards.map(
-                (card, idx) =>
-                  card && (
-                    <div
-                      key={idx}
-                      className={`inline-flex items-center justify-center rounded-md border border-gray-600 text-2xl px-2 py-1 mx-1 mb-2 bg-gray-800 font-bold ${
-                        card.suit === "h" || card.suit === "d"
-                          ? "text-red-500"
-                          : "text-white"
-                      }`}
-                    >
-                      {card.rank}
-                      {card.suit === "h"
-                        ? "♥"
-                        : card.suit === "d"
-                        ? "♦"
-                        : card.suit === "s"
-                        ? "♠"
-                        : "♣"}
-                    </div>
-                  )
-              )}
-            </div>
-          )}
-
-        {/* Card selection */}
-        <div className="flex flex-wrap gap-4">
-          {[0, 1, 2].map((index) => (
-            <div key={index} className="space-y-2">
-              <label className="block text-xs">カード {index + 1}</label>
-              <div>
-                {handHistory.flopCards[index]?.rank &&
-                handHistory.flopCards[index]?.suit ? (
-                  <button
-                    type="button"
-                    onClick={() => openFlopCardSelector(index as 0 | 1 | 2)}
-                    className="hover:scale-105 transition-transform"
-                  >
-                    <CardDisplay
-                      rank={handHistory.flopCards[index]!.rank}
-                      suit={handHistory.flopCards[index]!.suit}
-                      size="md"
-                    />
-                  </button>
-                ) : (
-                  <button
-                    type="button"
-                    onClick={() => openFlopCardSelector(index as 0 | 1 | 2)}
-                    className="inline-flex items-center justify-center rounded-md border border-gray-600 text-2xl px-4 py-2 mx-1 bg-gray-800 text-gray-400 hover:bg-gray-700 transition-colors h-10 w-16"
-                  >
-                    選択
-                  </button>
-                )}
-              </div>
-            </div>
-          ))}
-        </div>
-      </div>
-
-      {/* Flop Actions */}
-      <div>
-        <label className="block mb-2 text-sm font-medium">
-          フロップのアクション
-        </label>
-
-        {handHistory.flopActions.length > 0 ? (
-          <div className="space-y-2 mb-4">
-            {handHistory.flopActions.map((action, index) => (
-              <div
-                key={index}
-                className={`flex items-center justify-between p-2 rounded-md ${
-                  action.action === "?"
-                    ? "bg-green-900"
-                    : action.position === handHistory.heroPosition
-                    ? "bg-blue-900"
-                    : "bg-gray-800"
-                }`}
-              >
-                <span>
-                  {action.position === handHistory.heroPosition
-                    ? `${action.position} (Hero)`
-                    : action.position}
-                  : {action.action === "?" ? "分析を求める" : action.action}
-                  {action.amount !== undefined
-                    ? ` ${action.amount.toFixed(1)}BB`
-                    : ""}
-                </span>
-                <button
-                  type="button"
-                  onClick={() => removeAction("flop", index)}
-                  className="text-red-500 hover:text-red-400"
-                >
-                  ×
-                </button>
-              </div>
-            ))}
-          </div>
-        ) : (
-          <p className="text-gray-400 text-sm mb-4">
-            アクションが記録されていません。
-          </p>
-        )}
-
-        <ActionInputComponent stage="flop" />
-      </div>
-
-      <div className="flex justify-between pt-4">
-        <button
-          type="button"
-          onClick={() => setStep(2)}
-          className="px-4 py-2 bg-gray-600 text-white rounded-md hover:bg-gray-700"
-        >
-          戻る
-        </button>
-        <button
-          type="button"
-          onClick={() => setStep(4)}
-          className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700"
-          disabled={
-            !handHistory.flopCards[0]?.rank ||
-            !handHistory.flopCards[0]?.suit ||
-            !handHistory.flopCards[1]?.rank ||
-            !handHistory.flopCards[1]?.suit ||
-            !handHistory.flopCards[2]?.rank ||
-            !handHistory.flopCards[2]?.suit
-          }
-        >
-          次へ
-        </button>
-      </div>
-    </div>
-  );
-
-  // Step 4: Turn
-  const renderTurnStep = () => (
-    <div className="space-y-6">
-      <h3 className="text-xl font-semibold">ターン</h3>
-
-      {/* Turn Card */}
-      <div>
-        <label className="block mb-2 text-sm font-medium">ターンカード</label>
-
-        {/* Visual card display */}
-        {handHistory.turnCard?.rank && handHistory.turnCard?.suit && (
-          <div className="mb-4 flex items-center flex-wrap">
-            <span className="mr-2">ターン:</span>
-            <div
-              className={`inline-flex items-center justify-center rounded-md border border-gray-600 text-2xl px-2 py-1 mx-1 mb-2 bg-gray-800 font-bold ${
-                handHistory.turnCard.suit === "h" ||
-                handHistory.turnCard.suit === "d"
-                  ? "text-red-500"
-                  : "text-white"
-              }`}
-            >
-              {handHistory.turnCard.rank}
-              {handHistory.turnCard.suit === "h"
-                ? "♥"
-                : handHistory.turnCard.suit === "d"
-                ? "♦"
-                : handHistory.turnCard.suit === "s"
-                ? "♠"
-                : "♣"}
-            </div>
-          </div>
-        )}
-
-        {/* Card selection */}
-        <div>
-          {handHistory.turnCard?.rank && handHistory.turnCard?.suit ? (
-            <button
-              type="button"
-              onClick={() => openTurnCardSelector()}
-              className="hover:scale-105 transition-transform"
-            >
-              <CardDisplay
-                rank={handHistory.turnCard.rank}
-                suit={handHistory.turnCard.suit}
-                size="md"
-              />
-            </button>
-          ) : (
-            <button
-              type="button"
-              onClick={() => openTurnCardSelector()}
-              className="inline-flex items-center justify-center rounded-md border border-gray-600 text-lg px-4 py-2 bg-gray-800 text-gray-400 hover:bg-gray-700 transition-colors"
-            >
-              ターンカードを選択
-            </button>
-          )}
-        </div>
-      </div>
-
-      {/* Turn Actions */}
-      <div>
-        <label className="block mb-2 text-sm font-medium">
-          ターンのアクション
-        </label>
-
-        {handHistory.turnActions.length > 0 ? (
-          <div className="space-y-2 mb-4">
-            {handHistory.turnActions.map((action, index) => (
-              <div
-                key={index}
-                className={`flex items-center justify-between p-2 rounded-md ${
-                  action.action === "?"
-                    ? "bg-green-900"
-                    : action.position === handHistory.heroPosition
-                    ? "bg-blue-900"
-                    : "bg-gray-800"
-                }`}
-              >
-                <span>
-                  {action.position === handHistory.heroPosition
-                    ? `${action.position} (Hero)`
-                    : action.position}
-                  : {action.action === "?" ? "分析を求める" : action.action}
-                  {action.amount !== undefined
-                    ? ` ${action.amount.toFixed(1)}BB`
-                    : ""}
-                </span>
-                <button
-                  type="button"
-                  onClick={() => removeAction("turn", index)}
-                  className="text-red-500 hover:text-red-400"
-                >
-                  ×
-                </button>
-              </div>
-            ))}
-          </div>
-        ) : (
-          <p className="text-gray-400 text-sm mb-4">
-            アクションが記録されていません。
-          </p>
-        )}
-
-        <ActionInputComponent stage="turn" />
-      </div>
-
-      <div className="flex justify-between pt-4">
-        <button
-          type="button"
-          onClick={() => setStep(3)}
-          className="px-4 py-2 bg-gray-600 text-white rounded-md hover:bg-gray-700"
-        >
-          戻る
-        </button>
-        <button
-          type="button"
-          onClick={() => setStep(5)}
-          className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700"
-          disabled={!handHistory.turnCard?.rank || !handHistory.turnCard?.suit}
-        >
-          次へ
-        </button>
-      </div>
-    </div>
-  );
-
-  // Step 5: River
-  const renderRiverStep = () => (
-    <div className="space-y-6">
-      <h3 className="text-xl font-semibold">リバー</h3>
-
-      {/* River Card */}
-      <div>
-        <label className="block mb-2 text-sm font-medium">リバーカード</label>
-
-        {/* Visual card display */}
-        {handHistory.riverCard?.rank && handHistory.riverCard?.suit && (
-          <div className="mb-4 flex items-center flex-wrap">
-            <span className="mr-2">リバー:</span>
-            <div
-              className={`inline-flex items-center justify-center rounded-md border border-gray-600 text-2xl px-2 py-1 mx-1 mb-2 bg-gray-800 font-bold ${
-                handHistory.riverCard.suit === "h" ||
-                handHistory.riverCard.suit === "d"
-                  ? "text-red-500"
-                  : "text-white"
-              }`}
-            >
-              {handHistory.riverCard.rank}
-              {handHistory.riverCard.suit === "h"
-                ? "♥"
-                : handHistory.riverCard.suit === "d"
-                ? "♦"
-                : handHistory.riverCard.suit === "s"
-                ? "♠"
-                : "♣"}
-            </div>
-          </div>
-        )}
-
-        {/* Card selection */}
-        <div>
-          {handHistory.riverCard?.rank && handHistory.riverCard?.suit ? (
-            <button
-              type="button"
-              onClick={() => openRiverCardSelector()}
-              className="hover:scale-105 transition-transform"
-            >
-              <CardDisplay
-                rank={handHistory.riverCard.rank}
-                suit={handHistory.riverCard.suit}
-                size="md"
-              />
-            </button>
-          ) : (
-            <button
-              type="button"
-              onClick={() => openRiverCardSelector()}
-              className="inline-flex items-center justify-center rounded-md border border-gray-600 text-lg px-4 py-2 bg-gray-800 text-gray-400 hover:bg-gray-700 transition-colors"
-            >
-              リバーカードを選択
-            </button>
-          )}
-        </div>
-      </div>
-
-      {/* River Actions */}
-      <div>
-        <label className="block mb-2 text-sm font-medium">
-          リバーのアクション
-        </label>
-
-        {handHistory.riverActions.length > 0 ? (
-          <div className="space-y-2 mb-4">
-            {handHistory.riverActions.map((action, index) => (
-              <div
-                key={index}
-                className={`flex items-center justify-between p-2 rounded-md ${
-                  action.action === "?"
-                    ? "bg-green-900"
-                    : action.position === handHistory.heroPosition
-                    ? "bg-blue-900"
-                    : "bg-gray-800"
-                }`}
-              >
-                <span>
-                  {action.position === handHistory.heroPosition
-                    ? `${action.position} (Hero)`
-                    : action.position}
-                  : {action.action === "?" ? "分析を求める" : action.action}
-                  {action.amount !== undefined
-                    ? ` ${action.amount.toFixed(1)}BB`
-                    : ""}
-                </span>
-                <button
-                  type="button"
-                  onClick={() => removeAction("river", index)}
-                  className="text-red-500 hover:text-red-400"
-                >
-                  ×
-                </button>
-              </div>
-            ))}
-            )
-          </div>
-        ) : (
-          <p className="text-gray-400 text-sm mb-4">
-            アクションが記録されていません。
-          </p>
-        )}
-
-        <ActionInputComponent stage="river" />
-      </div>
-
-      <div className="flex justify-between pt-4">
-        <button
-          type="button"
-          onClick={() => setStep(4)}
-          className="px-4 py-2 bg-gray-600 text-white rounded-md hover:bg-gray-700"
-        >
-          戻る
-        </button>
-        <button
-          type="button"
-          onClick={() => setStep(6)}
-          className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700"
-          disabled={
-            !handHistory.riverCard?.rank || !handHistory.riverCard?.suit
-          }
-        >
-          確認して解析
-        </button>
-      </div>
-    </div>
-  );
-
-  // Step 6: Review and Submit
-  const renderReviewStep = () => (
-    <div className="space-y-6">
-      <h3 className="text-xl font-semibold">確認と解析</h3>
-
-      <div className="bg-gray-800 p-4 rounded-md whitespace-pre-wrap font-mono text-sm">
-        {formatHandHistory()}
-      </div>
-
-      <div className="flex justify-between pt-4">
-        <button
-          type="button"
-          onClick={() => setStep(5)}
-          className="px-4 py-2 bg-gray-600 text-white rounded-md hover:bg-gray-700"
-        >
-          戻る
-        </button>
-        <button
-          type="submit"
-          disabled={isLoading}
-          className="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 disabled:bg-green-800"
-        >
-          {isLoading ? "解析中..." : "ハンド解析する"}
-        </button>
-      </div>
-    </div>
-  );
-
-  // カード選択モーダル
-  const CardSelectorModal = () => {
-    // すでに使用済みのカードは選択できないようにする
-    const isCardAvailable = (rank: string, suit: string): boolean => {
-      // 現在編集中のカードは選択可能
-      if (
-        currentCardType === "hero" &&
-        handHistory.heroHand[currentCardIndex]?.rank === rank &&
-        handHistory.heroHand[currentCardIndex]?.suit === suit
-      ) {
-        return true;
+    // Check Flop Cards
+    [0, 1, 2].forEach((idx) => {
+      if (!(currentCardType === "flop" && currentFlopIndex === idx)) {
+        if (
+          handHistory.flopCards[idx]?.rank === rank &&
+          handHistory.flopCards[idx]?.suit === suit
+        ) {
+          isUsedElsewhere = true;
+        }
       }
+    });
+    if (isUsedElsewhere) return false;
 
+    // Check Turn Card
+    if (!(currentCardType === "turn")) {
       if (
-        currentCardType === "flop" &&
-        handHistory.flopCards[currentFlopIndex]?.rank === rank &&
-        handHistory.flopCards[currentFlopIndex]?.suit === suit
-      ) {
-        return true;
-      }
-
-      if (
-        currentCardType === "turn" &&
         handHistory.turnCard?.rank === rank &&
         handHistory.turnCard?.suit === suit
       ) {
-        return true;
+        isUsedElsewhere = true;
       }
+    }
+    if (isUsedElsewhere) return false;
 
+    // Check River Card
+    if (!(currentCardType === "river")) {
       if (
-        currentCardType === "river" &&
         handHistory.riverCard?.rank === rank &&
         handHistory.riverCard?.suit === suit
       ) {
-        return true;
+        isUsedElsewhere = true;
       }
+    }
+    if (isUsedElsewhere) return false;
 
-      // 他のカードが同じカードを使っていないか確認
-      return !isCardUsed(rank, suit);
-    };
-
-    return (
-      <div
-        className={`fixed inset-0 bg-black/70 flex items-center justify-center z-50 ${
-          cardSelectorOpen ? "" : "hidden"
-        }`}
-      >
-        <div className="bg-gray-800 rounded-lg p-6 w-full max-w-xl max-h-[80vh] overflow-y-auto">
-          <div className="flex justify-between items-center mb-4">
-            <h3 className="text-xl font-bold">
-              {currentCardType === "hero"
-                ? `カード${currentCardIndex + 1}を選択`
-                : currentCardType === "flop"
-                ? `フロップ${currentFlopIndex + 1}を選択`
-                : currentCardType === "turn"
-                ? "ターンカードを選択"
-                : "リバーカードを選択"}
-            </h3>
-            <button
-              type="button"
-              onClick={() => setCardSelectorOpen(false)}
-              className="text-gray-400 hover:text-white"
-            >
-              ✕
-            </button>
-          </div>
-
-          <div className="grid grid-cols-4 gap-2 sm:grid-cols-6 md:grid-cols-8">
-            {ranks.flatMap((rank) =>
-              suits.map((suit) => {
-                const available = isCardAvailable(rank, suit);
-                return (
-                  <button
-                    key={`${rank}${suit}`}
-                    type="button"
-                    disabled={!available}
-                    onClick={() => available && selectCard(rank, suit)}
-                    className={`${
-                      available
-                        ? "cursor-pointer hover:scale-110 transition-transform"
-                        : "opacity-30 cursor-not-allowed"
-                    }`}
-                  >
-                    <CardDisplay rank={rank} suit={suit} size="md" />
-                  </button>
-                );
-              })
-            )}
-          </div>
-        </div>
-      </div>
-    );
+    return true; // Card is not used elsewhere
   };
 
+  // --- Navigation ---
+  const nextStep = () => setStep((s) => Math.min(s + 1, 6));
+  const prevStep = () => setStep((s) => Math.max(s - 1, 1));
+
+  // --- Render Logic ---
   return (
     <div className="w-full max-w-4xl mx-auto">
       <h2 className="text-2xl font-bold mb-6">ポーカーハンド解析</h2>
 
+      {/* Step Indicator */}
       <div className="mb-8">
         <div className="flex justify-between">
           {[1, 2, 3, 4, 5, 6].map((stepNum) => (
@@ -1776,12 +458,12 @@ export default function PokerForm({
                 }
               }}
               disabled={stepNum > step}
-              className={`w-8 h-8 rounded-full flex items-center justify-center ${
+              className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${
                 stepNum === step
-                  ? "bg-blue-600 text-white"
+                  ? "bg-blue-600 text-white font-bold"
                   : stepNum < step
-                  ? "bg-blue-800 text-white"
-                  : "bg-gray-700 text-white opacity-50"
+                  ? "bg-blue-800 text-white hover:bg-blue-700"
+                  : "bg-gray-700 text-gray-400 cursor-not-allowed"
               }`}
             >
               {stepNum}
@@ -1798,17 +480,177 @@ export default function PokerForm({
         </div>
       </div>
 
+      {/* Form Content */}
       <form onSubmit={handleSubmit} className="bg-gray-900 p-6 rounded-lg">
-        {step === 1 && renderBasicInfoStep()}
-        {step === 2 && renderPreflopStep()}
-        {step === 3 && renderFlopStep()}
-        {step === 4 && renderTurnStep()}
-        {step === 5 && renderRiverStep()}
-        {step === 6 && renderReviewStep()}
+        {step === 1 && (
+          <BasicInfoForm
+            handHistory={handHistory}
+            getAvailablePositions={getAvailablePositions}
+            adjustPlayerCount={adjustPlayerCount}
+            updateStack={updateStack}
+            updateHeroPosition={updateHeroPosition}
+            openCardSelector={openCardSelector}
+            onNext={nextStep}
+          />
+        )}
+        {step === 2 && (
+          <StreetActionsForm
+            stage="preflop"
+            handHistory={handHistory}
+            getAvailablePositions={getAvailablePositions}
+            addAction={addAction}
+            removeAction={removeAction}
+            onAnalyze={onAnalyze}
+            formatHandHistory={formatHandHistory}
+            onNext={nextStep}
+            onBack={prevStep}
+          />
+        )}
+        {step === 3 && (
+          <div className="space-y-6">
+            <BoardCardInput
+              stage="flop"
+              handHistory={handHistory}
+              openFlopCardSelector={openFlopCardSelector}
+            />
+            <StreetActionsForm
+              stage="flop"
+              handHistory={handHistory}
+              getAvailablePositions={getAvailablePositions}
+              addAction={addAction}
+              removeAction={removeAction}
+              onAnalyze={onAnalyze}
+              formatHandHistory={formatHandHistory}
+              onNext={() => {}} // Disable internal nav
+              onBack={() => {}} // Disable internal nav
+            />
+            {/* Flop Step Navigation */}
+            <div className="flex justify-between pt-4">
+              <button
+                type="button"
+                onClick={prevStep}
+                className="px-4 py-2 bg-gray-600 text-white rounded-md hover:bg-gray-700"
+              >
+                戻る
+              </button>
+              <button
+                type="button"
+                onClick={nextStep}
+                className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50"
+                disabled={
+                  !handHistory.flopCards[0]?.rank ||
+                  !handHistory.flopCards[0]?.suit ||
+                  !handHistory.flopCards[1]?.rank ||
+                  !handHistory.flopCards[1]?.suit ||
+                  !handHistory.flopCards[2]?.rank ||
+                  !handHistory.flopCards[2]?.suit
+                }
+              >
+                次へ
+              </button>
+            </div>
+          </div>
+        )}
+        {step === 4 && (
+          <div className="space-y-6">
+            <BoardCardInput
+              stage="turn"
+              handHistory={handHistory}
+              openTurnCardSelector={openTurnCardSelector}
+            />
+            <StreetActionsForm
+              stage="turn"
+              handHistory={handHistory}
+              getAvailablePositions={getAvailablePositions}
+              addAction={addAction}
+              removeAction={removeAction}
+              onAnalyze={onAnalyze}
+              formatHandHistory={formatHandHistory}
+              onNext={() => {}} // Disable internal nav
+              onBack={() => {}} // Disable internal nav
+            />
+            {/* Turn Step Navigation */}
+            <div className="flex justify-between pt-4">
+              <button
+                type="button"
+                onClick={prevStep}
+                className="px-4 py-2 bg-gray-600 text-white rounded-md hover:bg-gray-700"
+              >
+                戻る
+              </button>
+              <button
+                type="button"
+                onClick={nextStep}
+                className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50"
+                disabled={
+                  !handHistory.turnCard?.rank || !handHistory.turnCard?.suit
+                }
+              >
+                次へ
+              </button>
+            </div>
+          </div>
+        )}
+        {step === 5 && (
+          <div className="space-y-6">
+            <BoardCardInput
+              stage="river"
+              handHistory={handHistory}
+              openRiverCardSelector={openRiverCardSelector}
+            />
+            <StreetActionsForm
+              stage="river"
+              handHistory={handHistory}
+              getAvailablePositions={getAvailablePositions}
+              addAction={addAction}
+              removeAction={removeAction}
+              onAnalyze={onAnalyze}
+              formatHandHistory={formatHandHistory}
+              onNext={() => {}} // Disable internal nav
+              onBack={() => {}} // Disable internal nav
+            />
+            {/* River Step Navigation */}
+            <div className="flex justify-between pt-4">
+              <button
+                type="button"
+                onClick={prevStep}
+                className="px-4 py-2 bg-gray-600 text-white rounded-md hover:bg-gray-700"
+              >
+                戻る
+              </button>
+              <button
+                type="button"
+                onClick={nextStep} // Go to Review Step
+                className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50"
+                disabled={
+                  !handHistory.riverCard?.rank || !handHistory.riverCard?.suit
+                }
+              >
+                確認して解析
+              </button>
+            </div>
+          </div>
+        )}
+        {step === 6 && (
+          <ReviewDisplay
+            formattedHistory={formatHandHistory()}
+            isLoading={isLoading}
+            onBack={prevStep}
+            onSubmit={handleSubmit}
+          />
+        )}
       </form>
 
-      {/* カード選択モーダル */}
-      <CardSelectorModal />
+      {/* Card Selector Modal */}
+      <CardSelectorModal
+        isOpen={cardSelectorOpen}
+        onClose={() => setCardSelectorOpen(false)}
+        onSelectCard={selectCard}
+        isCardAvailable={isCardAvailableForModal}
+        currentCardType={currentCardType}
+        currentCardIndex={currentCardIndex}
+        currentFlopIndex={currentFlopIndex}
+      />
     </div>
   );
 }

--- a/app/components/ReviewDisplay.tsx
+++ b/app/components/ReviewDisplay.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+interface ReviewDisplayProps {
+  formattedHistory: string;
+  isLoading: boolean;
+  onBack: () => void;
+  onSubmit: (e: React.FormEvent) => void; // Pass the submit handler
+}
+
+export default function ReviewDisplay({
+  formattedHistory,
+  isLoading,
+  onBack,
+  onSubmit,
+}: ReviewDisplayProps) {
+  return (
+    <div className="space-y-6">
+      <h3 className="text-xl font-semibold">確認と解析</h3>
+
+      <div className="bg-gray-800 p-4 rounded-md whitespace-pre-wrap font-mono text-sm">
+        {formattedHistory}
+      </div>
+
+      <div className="flex justify-between pt-4">
+        <button
+          type="button"
+          onClick={onBack}
+          className="px-4 py-2 bg-gray-600 text-white rounded-md hover:bg-gray-700"
+        >
+          戻る
+        </button>
+        <button
+          type="submit" // Changed to type="submit" to trigger form submission
+          disabled={isLoading}
+          className="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 disabled:bg-green-800"
+          onClick={onSubmit} // Attach the submit handler here as well if needed, or rely on form's onSubmit
+        >
+          {isLoading ? "解析中..." : "ハンド解析する"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/components/StreetActionsForm.tsx
+++ b/app/components/StreetActionsForm.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+import { useState } from "react";
+import {
+  HandHistoryState,
+  Position,
+  Action,
+  ActionEntry,
+  Street,
+} from "./types";
+
+interface StreetActionsFormProps {
+  stage: Street;
+  handHistory: HandHistoryState;
+  getAvailablePositions: () => Position[];
+  addAction: (stage: Street, action: ActionEntry) => void;
+  removeAction: (stage: Street, index: number) => void;
+  onAnalyze: (history: string) => void; // "?" アクション用
+  formatHandHistory: () => string; // "?" アクション用
+  onNext: () => void;
+  onBack: () => void;
+}
+
+const streetTitles: Record<Street, string> = {
+  preflop: "プリフロップ",
+  flop: "フロップ",
+  turn: "ターン",
+  river: "リバー",
+};
+
+const actions: Action[] = [
+  "fold",
+  "check",
+  "call",
+  "bet",
+  "raise",
+  "all-in",
+  "?",
+];
+
+export default function StreetActionsForm({
+  stage,
+  handHistory,
+  getAvailablePositions,
+  addAction,
+  removeAction,
+  onAnalyze,
+  formatHandHistory,
+  onNext,
+  onBack,
+}: StreetActionsFormProps) {
+  const [newAction, setNewAction] = useState<ActionEntry>({
+    position: handHistory.heroPosition,
+    action: "check",
+    amount: undefined,
+  });
+
+  const needsAmount = ["bet", "raise", "call"].includes(newAction.action);
+  const isQuestion = newAction.action === "?";
+  const currentActions = handHistory[`${stage}Actions`];
+
+  const handleAddAction = () => {
+    const actionToAdd = { ...newAction };
+    if (actionToAdd.action === "?") {
+      actionToAdd.isQuestion = true;
+    }
+    addAction(stage, actionToAdd);
+
+    // "?" アクションの場合はすぐに解析実行
+    if (actionToAdd.action === "?") {
+      // ステート更新が反映されるのを待つために少し遅延させる
+      setTimeout(() => {
+        const formattedHistory = formatHandHistory(); // 最新の状態でフォーマット
+        onAnalyze(formattedHistory);
+        // 解析セクションへスクロール
+        setTimeout(() => {
+          document
+            .getElementById("analysis-section")
+            ?.scrollIntoView({ behavior: "smooth" });
+        }, 300);
+      }, 10);
+    }
+
+    // フォームをリセット (Heroのポジションは維持)
+    setNewAction({
+      position: handHistory.heroPosition,
+      action: "check",
+      amount: undefined,
+    });
+  };
+
+  return (
+    <div className="space-y-6">
+      <h3 className="text-xl font-semibold">{streetTitles[stage]}</h3>
+
+      {/* Action List */}
+      <div>
+        <label className="block mb-2 text-sm font-medium">
+          {streetTitles[stage]}のアクション
+        </label>
+
+        {currentActions.length > 0 ? (
+          <div className="space-y-2 mb-4">
+            {currentActions.map((action, index) => (
+              <div
+                key={`${stage}-${index}`}
+                className={`flex items-center justify-between p-2 rounded-md ${
+                  action.action === "?"
+                    ? "bg-green-900"
+                    : action.position === handHistory.heroPosition
+                    ? "bg-blue-900"
+                    : "bg-gray-800"
+                }`}
+              >
+                <span>
+                  {action.position === handHistory.heroPosition
+                    ? `${action.position} (Hero)`
+                    : action.position}
+                  : {action.action === "?" ? "分析を求める" : action.action}
+                  {action.amount !== undefined
+                    ? ` ${action.amount.toFixed(1)}BB`
+                    : ""}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => removeAction(stage, index)}
+                  className="text-red-500 hover:text-red-400"
+                >
+                  ×
+                </button>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="text-gray-400 text-sm mb-4">
+            アクションが記録されていません。
+          </p>
+        )}
+      </div>
+
+      {/* Action Input Form */}
+      <div className="space-y-4 border border-gray-700 rounded-md p-4 mt-4">
+        <div className="flex justify-between items-center">
+          <h4 className="font-medium">新しいアクション</h4>
+          <div className="text-sm bg-blue-900 px-3 py-1 rounded-md">
+            現在のポット:{" "}
+            <span className="font-bold">
+              {handHistory.potSize.toFixed(1)}BB
+            </span>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="block text-xs mb-1">ポジション</label>
+            <select
+              value={newAction.position}
+              onChange={(e) =>
+                setNewAction({
+                  ...newAction,
+                  position: e.target.value as Position,
+                })
+              }
+              className="w-full p-2 bg-white/5 border border-gray-600 rounded-md"
+            >
+              {getAvailablePositions().map((pos) => (
+                <option key={pos} value={pos}>
+                  {pos === handHistory.heroPosition ? `${pos} (Hero)` : pos}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-xs mb-1">アクション</label>
+            <select
+              value={newAction.action}
+              onChange={(e) =>
+                setNewAction({ ...newAction, action: e.target.value as Action })
+              }
+              className="w-full p-2 bg-white/5 border border-gray-600 rounded-md"
+            >
+              {actions.map((action) => (
+                <option key={action} value={action}>
+                  {action === "?" ? "? (解析)" : action}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {needsAmount && (
+            <div className="col-span-2">
+              <label className="block text-xs mb-1">金額 (BB)</label>
+              <input
+                type="number"
+                min="0.5"
+                step="0.5"
+                value={newAction.amount || ""}
+                onChange={(e) =>
+                  setNewAction({
+                    ...newAction,
+                    amount: parseFloat(e.target.value) || undefined,
+                  })
+                }
+                className="w-full p-2 bg-white/5 border border-gray-600 rounded-md"
+              />
+            </div>
+          )}
+        </div>
+
+        <div className="flex justify-between items-center">
+          <button
+            type="button"
+            onClick={handleAddAction}
+            className={`px-3 py-1 ${
+              isQuestion
+                ? "bg-green-600 hover:bg-green-700"
+                : "bg-blue-600 hover:bg-blue-700"
+            } text-white rounded-md`}
+            disabled={needsAmount && !newAction.amount}
+          >
+            {isQuestion ? "解析する" : "追加"}
+          </button>
+
+          {isQuestion && (
+            <div className="text-yellow-400 text-sm italic text-right">
+              「?」を追加すると、この時点での最適なアクションを解析します
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Navigation */}
+      <div className="flex justify-between pt-4">
+        <button
+          type="button"
+          onClick={onBack}
+          className="px-4 py-2 bg-gray-600 text-white rounded-md hover:bg-gray-700"
+        >
+          戻る
+        </button>
+        <button
+          type="button"
+          onClick={onNext}
+          className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700"
+        >
+          次へ
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/components/types.ts
+++ b/app/components/types.ts
@@ -1,0 +1,57 @@
+export type Position =
+  | "BTN"
+  | "SB"
+  | "BB"
+  | "UTG"
+  | "UTG+1"
+  | "MP"
+  | "MP+1"
+  | "HJ"
+  | "CO";
+
+export type Card = { rank: string; suit: string };
+
+export type Action =
+  | "fold"
+  | "check"
+  | "call"
+  | "bet"
+  | "raise"
+  | "all-in"
+  | "?";
+
+export interface ActionEntry {
+  position: Position;
+  action: Action;
+  amount?: number;
+  isQuestion?: boolean;
+}
+
+export interface StackEntry {
+  position: Position;
+  stack: number;
+  isHero?: boolean;
+}
+
+export interface HandHistoryState {
+  heroHand: [Card | null, Card | null];
+  heroPosition: Position;
+  playerCount: number;
+  stacks: StackEntry[];
+  potSize: number;
+
+  preflopActions: Array<ActionEntry>;
+
+  flopCards: [Card | null, Card | null, Card | null];
+  flopActions: Array<ActionEntry>;
+
+  turnCard: Card | null;
+  turnActions: Array<ActionEntry>;
+
+  riverCard: Card | null;
+  riverActions: Array<ActionEntry>;
+
+  usedCards: Set<string>; // カードの重複使用を防ぐために使われたカードを追跡
+}
+
+export type Street = "preflop" | "flop" | "turn" | "river";


### PR DESCRIPTION
PokerForm コンポーネントをより小さなコンポーネント (BasicInfoForm, StreetActionsForm, BoardCardInput, ReviewDisplay, CardSelectorModal) に分割し、関心の分離を改善しました。