### PR TITLE
Fix: Handle pot calculation and call action amount (Issues #5, #6)

### DIFF
--- a/app/components/StreetActionsForm.tsx
+++ b/app/components/StreetActionsForm.tsx
@@ -55,7 +55,7 @@ export default function StreetActionsForm({
     amount: undefined,
   });
 
-  const needsAmount = ["bet", "raise", "call"].includes(newAction.action);
+  const needsAmount = ["bet", "raise"].includes(newAction.action); // 'call' を除外
   const isQuestion = newAction.action === "?";
   const currentActions = handHistory[`${stage}Actions`];
 


### PR DESCRIPTION
Closes #5
Closes #6

- コールアクション時にベット額の入力を不要にしました。
- ポットサイズの計算ロジックを修正し、初期ポット額（BB+SB+Ante）と全ストリートのアクション額を反映するようにしました。