### PR TITLE
Fix: Adjust position order based on street (Issue #7)

### DIFF
--- a/app/components/PokerForm.tsx
+++ b/app/components/PokerForm.tsx
@@ -74,10 +74,40 @@ export default function PokerForm({
 
   // --- Helper Functions ---
 
-  const getAvailablePositions = (): Position[] => {
-    const basePositions =
+  // Define standard position orders
+  const preflopOrder: Position[] = [
+    "UTG",
+    "UTG+1",
+    "MP",
+    "MP+1",
+    "HJ",
+    "CO",
+    "BTN",
+    "SB",
+    "BB",
+  ];
+  const postflopOrder: Position[] = [
+    "SB",
+    "BB",
+    "UTG",
+    "UTG+1",
+    "MP",
+    "MP+1",
+    "HJ",
+    "CO",
+    "BTN",
+  ];
+
+  const getAvailablePositions = (stage: Street): Position[] => {
+    const allPossiblePositions =
       positionsByPlayerCount[handHistory.playerCount] ||
       positionsByPlayerCount[6];
+    const currentOrder = stage === "preflop" ? preflopOrder : postflopOrder;
+
+    // Filter the standard order to include only positions relevant for the player count
+    const basePositions = currentOrder.filter((pos) =>
+      allPossiblePositions.includes(pos)
+    );
 
     const foldedPositions = new Set<Position>();
     const allActions: ActionEntry[] = [

--- a/app/components/StreetActionsForm.tsx
+++ b/app/components/StreetActionsForm.tsx
@@ -12,7 +12,7 @@ import {
 interface StreetActionsFormProps {
   stage: Street;
   handHistory: HandHistoryState;
-  getAvailablePositions: () => Position[];
+  getAvailablePositions: (stage: Street) => Position[]; // Updated signature
   addAction: (stage: Street, action: ActionEntry) => void;
   removeAction: (stage: Street, index: number) => void;
   onAnalyze: (history: string) => void; // "?" アクション用
@@ -163,11 +163,15 @@ export default function StreetActionsForm({
               }
               className="w-full p-2 bg-white/5 border border-gray-600 rounded-md"
             >
-              {getAvailablePositions().map((pos) => (
-                <option key={pos} value={pos}>
-                  {pos === handHistory.heroPosition ? `${pos} (Hero)` : pos}
-                </option>
-              ))}
+              {getAvailablePositions(stage).map(
+                (
+                  pos // Pass stage here
+                ) => (
+                  <option key={pos} value={pos}>
+                    {pos === handHistory.heroPosition ? `${pos} (Hero)` : pos}
+                  </option>
+                )
+              )}
             </select>
           </div>
 


### PR DESCRIPTION
Closes #7

- `getAvailablePositions` 関数を修正し、ストリート（プリフロップ/ポストフロップ）に基づいて正しいアクション順でポジションを表示するようにしました。
- `StreetActionsForm` で `getAvailablePositions` を呼び出す際に現在のストリートを渡すように修正しました。